### PR TITLE
use dict_merge to fix overwriting metadata

### DIFF
--- a/aiida_lsmo/workchains/isotherm.py
+++ b/aiida_lsmo/workchains/isotherm.py
@@ -10,6 +10,7 @@ from aiida.orm import Dict, Str, List, SinglefileData
 from aiida.engine import calcfunction
 from aiida.engine import WorkChain, ToContext, append_, while_, if_
 from aiida_lsmo.utils import check_resize_unit_cell, aiida_dict_merge
+from aiida_lsmo.utils import dict_merge
 
 # import sub-workchains
 RaspaBaseWorkChain = WorkflowFactory('raspa.base')  # pylint: disable=invalid-name
@@ -283,15 +284,16 @@ class IsothermWorkChain(WorkChain):
         inputs = self.exposed_inputs(ZeoppCalculation, 'zeopp')
 
         # Set inputs for zeopp
-        inputs.update({
-            'metadata': {
-                'label': "ZeoppVolpoBlock",
-                'call_link_label': 'run_zeopp_block_and_volpo',
-            },
-            'structure': self.inputs.structure,
-            'atomic_radii': get_atomic_radii(self.ctx.parameters),
-            'parameters': get_zeopp_parameters(self.ctx.molecule, self.ctx.parameters)
-        })
+        dict_merge(
+            inputs, {
+                'metadata': {
+                    'label': "ZeoppVolpoBlock",
+                    'call_link_label': 'run_zeopp_block_and_volpo',
+                },
+                'structure': self.inputs.structure,
+                'atomic_radii': get_atomic_radii(self.ctx.parameters),
+                'parameters': get_zeopp_parameters(self.ctx.molecule, self.ctx.parameters)
+            })
 
         running = self.submit(ZeoppCalculation, **inputs)
         self.report("Running zeo++ block and volpo Calculation<{}>".format(running.id))

--- a/aiida_lsmo/workchains/isotherm_calc_pe.py
+++ b/aiida_lsmo/workchains/isotherm_calc_pe.py
@@ -7,6 +7,7 @@ from aiida.plugins import DataFactory, WorkflowFactory
 from aiida.orm import Dict, Str
 from aiida.engine import calcfunction
 from aiida.engine import WorkChain
+from aiida_lsmo.utils import dict_merge
 
 # import sub-workchains
 IsothermWorkChain = WorkflowFactory('lsmo.isotherm')  #pylint: disable=invalid-name
@@ -123,13 +124,14 @@ class IsothermCalcPEWorkChain(WorkChain):
 
         for mol in ['co2', 'n2']:
 
-            inputs.update({
-                'metadata': {
-                    'call_link_label': 'run_isotherm_for_{}'.format(mol),
-                },
-                'molecule': Str(mol),
-                'parameters': self.inputs.parameters
-            })
+            dict_merge(
+                inputs, {
+                    'metadata': {
+                        'call_link_label': 'run_isotherm_for_{}'.format(mol),
+                    },
+                    'molecule': Str(mol),
+                    'parameters': self.inputs.parameters
+                })
 
             running = self.submit(IsothermWorkChain, **inputs)
             self.to_context(**{'isotherm_{}'.format(mol): running})

--- a/aiida_lsmo/workchains/isotherm_multi_temp.py
+++ b/aiida_lsmo/workchains/isotherm_multi_temp.py
@@ -8,6 +8,7 @@ from aiida.plugins import WorkflowFactory
 from aiida.orm import Dict
 from aiida.engine import calcfunction
 from aiida.engine import WorkChain, ToContext, if_
+from aiida_lsmo.utils import dict_merge
 
 # import sub-workchains
 IsothermWorkChain = WorkflowFactory('lsmo.isotherm')  # pylint: disable=invalid-name
@@ -84,7 +85,7 @@ class IsothermMultiTempWorkChain(WorkChain):
         inputs = self.exposed_inputs(IsothermWorkChain)
 
         # Set inputs for zeopp
-        inputs.update({
+        dict_merge(inputs, {
             'metadata': {
                 'label': "IsothermGeometric",
                 'call_link_label': 'run_geometric',
@@ -119,13 +120,14 @@ class IsothermMultiTempWorkChain(WorkChain):
         for i in range(self.ctx.ntemp):
             self.ctx.parameters_singletemp = get_parameters_singletemp(i, self.inputs.parameters)
 
-            inputs.update({
-                'metadata': {
-                    'label': "Isotherm_{}".format(i),
-                    'call_link_label': 'run_isotherm_{}'.format(i),
-                },
-                'parameters': self.ctx.parameters_singletemp
-            })
+            dict_merge(
+                inputs, {
+                    'metadata': {
+                        'label': "Isotherm_{}".format(i),
+                        'call_link_label': 'run_isotherm_{}'.format(i),
+                    },
+                    'parameters': self.ctx.parameters_singletemp
+                })
 
             running = self.submit(IsothermWorkChain, **inputs)
             self.to_context(**{'isotherm_{}'.format(i): running})


### PR DESCRIPTION
In the last release, by labeling the nodes/link, I was overwriting the full metadata dict, and in some cases this resulted in having user settings (e.g., `options` to set the walltime) disappear.