### PR TITLE
Move workchains to lsmo

### DIFF
--- a/aiida_lsmo/calcfunctions/ff_builder_module.py
+++ b/aiida_lsmo/calcfunctions/ff_builder_module.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """ff_builder calcfunction."""
 import tempfile
 import shutil

--- a/aiida_lsmo/calcfunctions/selectivity.py
+++ b/aiida_lsmo/calcfunctions/selectivity.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Calcfunctions to compute gas-selectivity related applications."""
 
 from aiida.engine import calcfunction

--- a/aiida_lsmo/calcfunctions/working_cap.py
+++ b/aiida_lsmo/calcfunctions/working_cap.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Calcfunctions to compute working capacities for different gasses."""
 
 from math import sqrt

--- a/aiida_lsmo/parsers/__init__.py
+++ b/aiida_lsmo/parsers/__init__.py
@@ -1,0 +1,93 @@
+"""Parsers for the specific usage of aiida-lsmo workchains."""
+
+import io
+import os
+
+from aiida.parsers import Parser
+from aiida.common import OutputParsingError, NotExistent
+from aiida.engine import ExitCode
+from aiida.orm import Dict
+from aiida_cp2k.parsers import Cp2kBaseParser
+
+
+class Cp2kBsseParser(Cp2kBaseParser):
+    """Advanced AiiDA parser class for a BSSE calculation in CP2K."""
+
+    def _parse_stdout(self, out_folder):
+        """BSSE CP2K output file parser"""
+
+        from .parser_functions import parse_cp2k_output_bsse
+
+        # pylint: disable=protected-access
+
+        fname = self.node.process_class._DEFAULT_OUTPUT_FILE
+        if fname not in out_folder._repository.list_object_names():
+            raise OutputParsingError("Cp2k output file not retrieved")
+
+        abs_fn = os.path.join(out_folder._repository._get_base_folder().abspath, fname)
+        with io.open(abs_fn, mode="r", encoding="utf-8") as fobj:
+            result_dict = parse_cp2k_output_bsse(fobj)
+
+        # nwarnings is the last thing to be printed in the CP2K output file:
+        # if it is not there, CP2K didn't finish properly
+        if 'nwarnings' not in result_dict:
+            raise OutputParsingError("CP2K did not finish properly.")
+
+        self.out("output_parameters", Dict(dict=result_dict))
+
+
+class Cp2kAdvancedParser(Cp2kBaseParser):
+    """Advanced AiiDA parser class for the output of CP2K."""
+
+    def _parse_stdout(self, out_folder):
+        """Advanced CP2K output file parser"""
+
+        from aiida.orm import BandsData
+        from .parser_functions import parse_cp2k_output_advanced
+
+        # pylint: disable=protected-access
+
+        fname = self.node.process_class._DEFAULT_OUTPUT_FILE
+        if fname not in out_folder._repository.list_object_names():
+            raise OutputParsingError("Cp2k output file not retrieved")
+
+        abs_fn = os.path.join(out_folder._repository._get_base_folder().abspath, fname)
+        with io.open(abs_fn, mode="r", encoding="utf-8") as fobj:
+            result_dict = parse_cp2k_output_advanced(fobj)
+
+        # nwarnings is the last thing to be printed in th eCP2K output file:
+        # if it is not there, CP2K didn't finish properly
+        if 'nwarnings' not in result_dict:
+            raise OutputParsingError("CP2K did not finish properly.")
+
+        # Compute the bandgap for Spin1 and Spin2 if eigen was parsed (works also with smearing!)
+        if 'eigen_spin1_au' in result_dict:
+            if result_dict['dft_type'] == "RKS":
+                result_dict['eigen_spin2_au'] = result_dict['eigen_spin1_au']
+
+            lumo_spin1_idx = result_dict['init_nel_spin1']
+            lumo_spin2_idx = result_dict['init_nel_spin2']
+            if (lumo_spin1_idx > len(result_dict['eigen_spin1_au'])-1) or \
+               (lumo_spin2_idx > len(result_dict['eigen_spin2_au'])-1):
+                #electrons jumped from spin1 to spin2 (or opposite): assume last eigen is lumo
+                lumo_spin1_idx = len(result_dict['eigen_spin1_au']) - 1
+                lumo_spin2_idx = len(result_dict['eigen_spin2_au']) - 1
+            homo_spin1 = result_dict['eigen_spin1_au'][lumo_spin1_idx - 1]
+            homo_spin2 = result_dict['eigen_spin2_au'][lumo_spin2_idx - 1]
+            lumo_spin1 = result_dict['eigen_spin1_au'][lumo_spin1_idx]
+            lumo_spin2 = result_dict['eigen_spin2_au'][lumo_spin2_idx]
+            result_dict['bandgap_spin1_au'] = lumo_spin1 - homo_spin1
+            result_dict['bandgap_spin2_au'] = lumo_spin2 - homo_spin2
+
+        if "kpoint_data" in result_dict:
+            bnds = BandsData()
+            bnds.set_kpoints(result_dict["kpoint_data"]["kpoints"])
+            bnds.labels = result_dict["kpoint_data"]["labels"]
+            bnds.set_bands(
+                result_dict["kpoint_data"]["bands"],
+                units=result_dict["kpoint_data"]["bands_unit"],
+            )
+            self.out("output_bands", bnds)
+            del result_dict["kpoint_data"]
+
+        self.out("output_parameters", Dict(dict=result_dict))

--- a/aiida_lsmo/parsers/__init__.py
+++ b/aiida_lsmo/parsers/__init__.py
@@ -3,10 +3,77 @@
 import io
 import os
 
+from aiida.parsers import Parser
 from aiida.common import OutputParsingError, NotExistent
 from aiida.engine import ExitCode
 from aiida.orm import Dict
-from aiida_cp2k.parsers import Cp2kBaseParser
+
+
+class Cp2kBaseParser(Parser):
+    """Basic AiiDA parser for the output of CP2K.
+    NOTE: copy of the parser in aiida_cp2k.parser, because the docs were failing when importing it from aiida_cp2k:
+    docstring of aiida_lsmo.parsers.Cp2kAdvancedParser:1:py:class
+    reference target not found: aiida_cp2k.parsers.Cp2kBaseParser
+    """
+
+    def parse(self, **kwargs):
+        """Receives in input a dictionary of retrieved nodes. Does all the logic here."""
+
+        try:
+            out_folder = self.retrieved
+        except NotExistent:
+            return self.exit_codes.ERROR_NO_RETRIEVED_FOLDER
+
+        self._parse_stdout(out_folder)
+
+        try:
+            structure = self._parse_trajectory(out_folder)
+            self.out('output_structure', structure)
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+        return ExitCode(0)
+
+    def _parse_stdout(self, out_folder):
+        """Basic CP2K output file parser"""
+
+        from aiida_cp2k.utils import parse_cp2k_output
+
+        # pylint: disable=protected-access
+
+        fname = self.node.process_class._DEFAULT_OUTPUT_FILE
+        if fname not in out_folder._repository.list_object_names():
+            raise OutputParsingError("Cp2k output file not retrieved")
+
+        abs_fn = os.path.join(out_folder._repository._get_base_folder().abspath, fname)
+
+        with io.open(abs_fn, mode="r", encoding="utf-8") as fobj:
+            result_dict = parse_cp2k_output(fobj)
+
+        if 'nwarnings' not in result_dict:
+            raise OutputParsingError("CP2K did not finish properly.")
+
+        self.out("output_parameters", Dict(dict=result_dict))
+
+    def _parse_trajectory(self, out_folder):
+        """CP2K trajectory parser"""
+
+        from ase import Atoms
+        from aiida.orm import StructureData
+        from aiida_cp2k.utils import parse_cp2k_trajectory
+
+        # pylint: disable=protected-access
+        fname = self.node.process_class._DEFAULT_RESTART_FILE_NAME
+
+        if fname not in out_folder._repository.list_object_names():
+            raise Exception("parsing trajectory requested, but no trajectory file available")
+
+        # read restart file
+        abs_fn = os.path.join(out_folder._repository._get_base_folder().abspath, fname)
+        with io.open(abs_fn, mode="r", encoding="utf-8") as fobj:
+            atoms = Atoms(**parse_cp2k_trajectory(fobj))
+
+        return StructureData(ase=atoms)
 
 
 class Cp2kBsseParser(Cp2kBaseParser):

--- a/aiida_lsmo/parsers/__init__.py
+++ b/aiida_lsmo/parsers/__init__.py
@@ -3,7 +3,6 @@
 import io
 import os
 
-from aiida.parsers import Parser
 from aiida.common import OutputParsingError, NotExistent
 from aiida.engine import ExitCode
 from aiida.orm import Dict

--- a/aiida_lsmo/parsers/parser_functions.py
+++ b/aiida_lsmo/parsers/parser_functions.py
@@ -1,0 +1,283 @@
+"""Functions used for specific parsing of output files."""
+
+import re
+
+from aiida_cp2k.utils.parser import _parse_bands
+
+
+def parse_cp2k_output_bsse(fobj):
+    """Parse CP2K BSSE output into a dictionary (tested with PRINT_LEVEL MEDIUM)."""
+    from aiida_lsmo.utils import HARTREE2KJMOL
+
+    lines = fobj.readlines()
+
+    result_dict = {
+        "exceeded_walltime": False,
+        "energy_description_list": [
+            "Energy of A with basis set A", "Energy of B with basis set B", "Energy of A with basis set of A+B",
+            "Energy of B with basis set of A+B", "Energy of A+B with basis set of A+B"
+        ],
+        "energy_list": [],
+        "energy_dispersion_list": []
+    }
+
+    read_energy = False
+    for line in lines:
+        if "The number of warnings for this run is" in line:
+            result_dict["nwarnings"] = int(line.split()[-1])
+        if "exceeded requested execution time" in line:
+            result_dict["exceeded_walltime"] = True
+        if "SCF run converged in" in line:
+            read_energy = True
+        if read_energy:
+            if r"Dispersion energy:" in line:
+                result_dict["energy_dispersion_list"].append(float(line.split()[-1]))
+            if r"  Total energy:" in line:
+                result_dict["energy_list"].append(float(line.split()[-1]))
+                read_energy = False
+
+    result_dict["energy"] = result_dict["energy_list"][4]
+    result_dict["energy_units"] = "a.u."
+    result_dict["binding_energy_raw"] = (result_dict["energy_list"][4] - result_dict["energy_list"][0] -
+                                         result_dict["energy_list"][1]) * HARTREE2KJMOL
+    result_dict["binding_energy_corr"] = (result_dict["energy_list"][4] - result_dict["energy_list"][2] -
+                                          result_dict["energy_list"][3]) * HARTREE2KJMOL
+    result_dict["binding_energy_bsse"] = result_dict["binding_energy_raw"] - result_dict["binding_energy_corr"]
+    result_dict["binding_energy_unit"] = "kJ/mol"
+    if result_dict["energy_dispersion_list"]:
+        result_dict["binding_energy_dispersion"] = (result_dict["energy_dispersion_list"][4] -
+                                                    result_dict["energy_dispersion_list"][0] -
+                                                    result_dict["energy_dispersion_list"][1]) * HARTREE2KJMOL
+
+    return result_dict
+
+
+def parse_cp2k_output_advanced(fobj):  # pylint: disable=too-many-locals, too-many-statements, too-many-branches
+    """Parse CP2K output into a dictionary (ADVANCED: more info parsed @ PRINT_LEVEL MEDIUM)"""
+    lines = fobj.readlines()
+
+    result_dict = {"exceeded_walltime": False}
+    result_dict['warnings'] = []
+    line_is = None
+    energy = None
+    bohr2ang = 0.529177208590000
+
+    for i_line, line in enumerate(lines):
+        if line.startswith(' ENERGY| '):
+            energy = float(line.split()[8])
+            result_dict['energy'] = energy
+            result_dict['energy_units'] = "a.u."
+        if 'The number of warnings for this run is' in line:
+            result_dict['nwarnings'] = int(line.split()[-1])
+        if 'exceeded requested execution time' in line:
+            result_dict['exceeded_walltime'] = True
+        if "KPOINTS| Band Structure Calculation" in line:
+            kpoints, labels, bands = _parse_bands(lines, i_line)
+            result_dict["kpoint_data"] = {
+                "kpoints": kpoints,
+                "labels": labels,
+                "bands": bands,
+                "bands_unit": "eV",
+            }
+        if line.startswith(' GLOBAL| Run type'):
+            result_dict['run_type'] = line.split()[-1]
+
+        if line.startswith(' MD| Ensemble Type'):
+            result_dict['run_type'] += '-'
+            result_dict['run_type'] += line.split()[-1]  #e.g., 'MD-NPT_F'
+
+        if line.startswith(' DFT| ') and 'dft_type' not in result_dict.keys():
+            result_dict['dft_type'] = line.split()[-1]  # RKS, UKS or ROKS
+
+        # read the number of electrons in the first scf (NOTE: it may change but it is not updated!)
+        if re.search('Number of electrons: ', line):
+            if 'init_nel_spin1' not in result_dict.keys():
+                result_dict['init_nel_spin1'] = int(line.split()[3])
+                if result_dict['dft_type'] == 'RKS':
+                    result_dict['init_nel_spin1'] //= 2  #// returns an integer
+                    result_dict['init_nel_spin2'] = result_dict['init_nel_spin1']
+            elif 'init_nel_spin2' not in result_dict.keys():
+                result_dict['init_nel_spin2'] = int(line.split()[3])
+
+        if re.search('- Atoms: ', line):
+            result_dict['natoms'] = int(line.split()[-1])
+
+        if re.search('Smear method', line):
+            result_dict['smear_method'] = line.split()[-1]
+
+        if re.search(r"subspace spin", line):
+            if int(line.split()[-1]) == 1:
+                line_is = 'eigen_spin1_au'
+                if 'eigen_spin1_au' not in result_dict.keys():
+                    result_dict['eigen_spin1_au'] = []
+            elif int(line.split()[-1]) == 2:
+                line_is = 'eigen_spin2_au'
+                if 'eigen_spin2_au' not in result_dict.keys():
+                    result_dict['eigen_spin2_au'] = []
+            continue
+
+        # Parse warnings
+        if re.search(r"Using a non-square number of", line):
+            result_dict['warnings'].append('Using a non-square number of MPI ranks')
+        if re.search(r"SCF run NOT converged", line):
+            warn = "One or more SCF run did not converge"
+            if warn not in result_dict['warnings']:
+                result_dict['warnings'].append(warn)
+        if re.search(r"Specific L-BFGS convergence criteria", line):
+            result_dict["warnings"].append("LBFGS converged with specific criteria")
+
+        # If a tag has been detected, now read the following line knowing what they are
+        if line_is is not None:
+            # Read eigenvalues as 4-columns row, then convert to float
+            if line_is in ['eigen_spin1_au', 'eigen_spin2_au']:
+                if re.search(r"-------------", line) or re.search(r"Reached convergence", line):
+                    continue
+                if line.split() and len(line.split()) <= 4:
+                    result_dict[line_is] += [float(x) for x in line.split()]
+                else:
+                    line_is = None
+
+        ####################################################################
+        #  THIS SECTION PARSES THE PROPERTIES AT GOE_OPT/CELL_OPT/MD STEP  #
+        #  BC: it can be not robust!                                         #
+        ####################################################################
+        if 'run_type' in result_dict.keys() and result_dict['run_type'] in [
+                'ENERGY', 'ENERGY_FORCE', 'GEO_OPT', 'CELL_OPT', 'MD', 'MD-NVT', 'MD-NPT_F'
+        ]:
+            # Initialization
+            if 'motion_step_info' not in result_dict:
+                result_dict['motion_opt_converged'] = False
+                result_dict['motion_step_info'] = {
+                    'step': [],  # MOTION step
+                    'energy_au': [],  # total energy
+                    'dispersion_energy_au': [],  # Dispersion energy (if dispersion correction activated)
+                    'pressure_bar': [],  # Total pressure on the cell
+                    'cell_vol_angs3': [],  # Cell Volume
+                    'cell_a_angs': [],  # Cell dimension A
+                    'cell_b_angs': [],  # Cell dimension B
+                    'cell_c_angs': [],  # Cell dimension C
+                    'cell_alp_deg': [],  # Cell angle Alpha
+                    'cell_bet_deg': [],  # Cell angle Beta
+                    'cell_gam_deg': [],  # Cell angle Gamma
+                    'max_step_au': [],  # Max atomic displacement (in optimization)
+                    'rms_step_au': [],  # RMS atomic displacement (in optimization)
+                    'max_grad_au': [],  # Max atomic force (in optimization)
+                    'rms_grad_au': [],  # RMS atomic force (in optimization)
+                    'edens_rspace': [],  # Total charge density on r-space grids (should stay small)
+                    'scf_converged': [],  # SCF converged in this motions step (bool)
+                }
+                step = 0
+                energy = None
+                dispersion = None  #Needed if no dispersions are included
+                pressure = None
+                max_step = None
+                rms_step = None
+                max_grad = None
+                rms_grad = None
+                edens_rspace = None
+                scf_converged = True
+
+            print_now = False
+            data = line.split()
+            # Parse general info
+            if line.startswith(' CELL|'):
+                if re.search(r"Volume", line):
+                    cell_vol = float(data[3])
+                if re.search(r"Vector a", line):
+                    cell_a = float(data[9])
+                if re.search(r"Vector b", line):
+                    cell_b = float(data[9])
+                if re.search(r"Vector c", line):
+                    cell_c = float(data[9])
+                if re.search(r"alpha", line):
+                    cell_alp = float(data[5])
+                if re.search(r"beta", line):
+                    cell_bet = float(data[5])
+                if re.search(r"gamma", line):
+                    cell_gam = float(data[5])
+
+            if re.search(r"Dispersion energy", line):
+                dispersion = float(data[2])
+            if re.search('Total charge density on r-space grids:', line):
+                # Printed at every outer OT, and needed for understanding if something is going wrong (if !=0)
+                edens_rspace = float(line.split()[-1])
+            if re.search(r"SCF run NOT converged", line):
+                scf_converged = False
+
+            # Parse specific info
+            if result_dict['run_type'] in ['ENERGY', 'ENERGY_FORCE']:
+                if energy is not None and not result_dict['motion_step_info']['step']:
+                    print_now = True
+            if result_dict['run_type'] in ['GEO_OPT', 'CELL_OPT']:
+                #Note: with CELL_OPT/LBFGS there is no "STEP 0", while there is with CELL_OPT/BFGS
+                if re.search(r"Informations at step", line):
+                    step = int(data[5])
+                if re.search(r"Max. step size             =", line):
+                    max_step = float(data[-1])
+                if re.search(r"RMS step size              =", line):
+                    rms_step = float(data[-1])
+                if re.search(r"Max. gradient              =", line):
+                    max_grad = float(data[-1])
+                if re.search(r"RMS gradient               =", line):
+                    rms_grad = float(data[-1])
+                if len(data) == 1 and data[0] == '---------------------------------------------------':
+                    print_now = True  # 51('-')
+                if re.search(r"Reevaluating energy at the minimum", line):  #not clear why it is doing a last one...
+                    result_dict['motion_opt_converged'] = True
+
+            if result_dict['run_type'] == 'CELL_OPT':
+                if re.search(r"Internal Pressure", line):
+                    pressure = float(data[4])
+            if result_dict['run_type'] == 'MD-NVT':
+                if re.search(r"STEP NUMBER", line):
+                    step = int(data[3])
+                if re.search(r"INITIAL PRESSURE\[bar\]", line):
+                    pressure = float(data[3])
+                    print_now = True
+                if re.search(r"PRESSURE \[bar\]", line):
+                    pressure = float(data[3])
+                    print_now = True
+            if result_dict['run_type'] == 'MD-NPT_F':
+                if re.search(r"^ STEP NUMBER", line):
+                    step = int(data[3])
+                if re.search(r"^ INITIAL PRESSURE\[bar\]", line):
+                    pressure = float(data[3])
+                    print_now = True
+                if re.search(r"^ PRESSURE \[bar\]", line):
+                    pressure = float(data[3])
+                if re.search(r"^ VOLUME\[bohr\^3\]", line):
+                    cell_vol = float(data[3]) * (bohr2ang**3)
+                if re.search(r"^ CELL LNTHS\[bohr\]", line):
+                    cell_a = float(data[3]) * bohr2ang
+                    cell_b = float(data[4]) * bohr2ang
+                    cell_c = float(data[5]) * bohr2ang
+                if re.search(r"^ CELL ANGLS\[deg\]", line):
+                    cell_alp = float(data[3])
+                    cell_bet = float(data[4])
+                    cell_gam = float(data[5])
+                    print_now = True
+
+            if print_now and energy is not None:
+                result_dict['motion_step_info']['step'].append(step)
+                result_dict['motion_step_info']['energy_au'].append(energy)
+                result_dict['motion_step_info']['dispersion_energy_au'].append(dispersion)
+                result_dict['motion_step_info']['pressure_bar'].append(pressure)
+                result_dict['motion_step_info']['cell_vol_angs3'].append(cell_vol)
+                result_dict['motion_step_info']['cell_a_angs'].append(cell_a)
+                result_dict['motion_step_info']['cell_b_angs'].append(cell_b)
+                result_dict['motion_step_info']['cell_c_angs'].append(cell_c)
+                result_dict['motion_step_info']['cell_alp_deg'].append(cell_alp)
+                result_dict['motion_step_info']['cell_bet_deg'].append(cell_bet)
+                result_dict['motion_step_info']['cell_gam_deg'].append(cell_gam)
+                result_dict['motion_step_info']['max_step_au'].append(max_step)
+                result_dict['motion_step_info']['rms_step_au'].append(rms_step)
+                result_dict['motion_step_info']['max_grad_au'].append(max_grad)
+                result_dict['motion_step_info']['rms_grad_au'].append(rms_grad)
+                result_dict['motion_step_info']['edens_rspace'].append(edens_rspace)
+                result_dict['motion_step_info']['scf_converged'].append(scf_converged)
+                scf_converged = True
+        ####################################################################
+        #  END PARSING GEO_OPT/CELL_OPT/MD STEP                            #
+        ####################################################################
+
+    return result_dict

--- a/aiida_lsmo/utils/__init__.py
+++ b/aiida_lsmo/utils/__init__.py
@@ -1,6 +1,7 @@
-# -*- coding: utf-8 -*-
 """aiida-lsmo utils"""
 from .multiply_unitcell import check_resize_unit_cell
 from .other_utilities import aiida_dict_merge, dict_merge, aiida_cif_merge, aiida_structure_merge
-from .other_utilities import get_kinds_with_ghost_section, get_bsse_section
 from .other_utilities import get_structure_from_cif, get_cif_from_structure
+
+HARTREE2EV = 27.211399
+HARTREE2KJMOL = 2625.500

--- a/aiida_lsmo/utils/cp2k_utils.py
+++ b/aiida_lsmo/utils/cp2k_utils.py
@@ -1,0 +1,123 @@
+"""Utilities related to CP2K."""
+
+from aiida_lsmo.utils import HARTREE2EV
+
+# Functions to get inputs
+
+
+def get_input_multiplicity(structure, protocol_settings):
+    """ Compute the total multiplicity of the structure,
+    by summing the atomic magnetizations:
+    multiplicity = 1 + sum_i ( natoms_i * magnetization_i ), for each atom_type i
+    """
+    multiplicity = 1
+    all_atoms = structure.get_ase().get_chemical_symbols()
+    for key, value in protocol_settings['initial_magnetization'].items():
+        multiplicity += all_atoms.count(key) * value
+    multiplicity = int(round(multiplicity))
+    multiplicity_dict = {'FORCE_EVAL': {'DFT': {'MULTIPLICITY': multiplicity}}}
+    if multiplicity != 1:
+        multiplicity_dict['FORCE_EVAL']['DFT']['UKS'] = True
+    return multiplicity_dict
+
+
+def get_kinds_section(structure, protocol_settings):
+    """ Write the &KIND sections given the structure and the settings_dict"""
+    kinds = []
+    all_atoms = set(structure.get_ase().get_chemical_symbols())
+    for atom in all_atoms:
+        kinds.append({
+            '_': atom,
+            'BASIS_SET': protocol_settings['basis_set'][atom],
+            'POTENTIAL': protocol_settings['pseudopotential'][atom],
+            'MAGNETIZATION': protocol_settings['initial_magnetization'][atom],
+        })
+    return {'FORCE_EVAL': {'SUBSYS': {'KIND': kinds}}}
+
+
+def get_kinds_with_ghost_section(structure, protocol_settings):
+    """Write the &KIND sections given the structure and the settings_dict, and add also GHOST atoms"""
+    kinds = []
+    all_atoms = set(structure.get_ase().get_chemical_symbols())
+    for atom in all_atoms:
+        kinds.append({
+            '_': atom,
+            'BASIS_SET': protocol_settings['basis_set'][atom],
+            'POTENTIAL': protocol_settings['pseudopotential'][atom],
+            'MAGNETIZATION': protocol_settings['initial_magnetization'][atom],
+        })
+        kinds.append({'_': atom + "_ghost", 'BASIS_SET': protocol_settings['basis_set'][atom], 'GHOST': True})
+    return {'FORCE_EVAL': {'SUBSYS': {'KIND': kinds}}}
+
+
+def get_bsse_section(natoms_a, natoms_b, mult_a=1, mult_b=1, charge_a=0, charge_b=0):
+    """Get the &FORCE_EVAL/&BSSE section."""
+    bsse_section = {
+        'FORCE_EVAL': {
+            'BSSE' : {
+                'FRAGMENT': [{
+                'LIST': '1..{}'.format(natoms_a)
+                },
+                {
+                'LIST': '{}..{}'.format(natoms_a + 1, natoms_a + natoms_b)
+                }],
+                'CONFIGURATION': [
+                    { # A fragment with basis set A
+                        'MULTIPLICITY': mult_a,
+                        'CHARGE': charge_a,
+                        'GLB_CONF': '1 0',
+                        'SUB_CONF': '1 0',
+                        },
+                    { # B fragment with basis set B
+                        'MULTIPLICITY': mult_b,
+                        'CHARGE': charge_b,
+                        'GLB_CONF': '0 1',
+                        'SUB_CONF': '0 1',
+                        },
+                    { # A fragment with basis set A+B
+                        'MULTIPLICITY': mult_a,
+                        'CHARGE': charge_a,
+                        'GLB_CONF': '1 1',
+                        'SUB_CONF': '1 0',
+                        },
+                    { # B fragment with basis set A+B
+                        'MULTIPLICITY': mult_b,
+                        'CHARGE': charge_b,
+                        'GLB_CONF': '1 1',
+                        'SUB_CONF': '0 1',
+                        },
+                    { # A+B fragments with basis set A+B
+                        'MULTIPLICITY': mult_a + mult_b - 1,
+                        'CHARGE': charge_a + charge_b,
+                        'GLB_CONF': '1 1',
+                        'SUB_CONF': '1 1',
+                        }
+                ]
+            }
+        }
+    }
+    return bsse_section
+
+
+# Functions to parse results
+
+
+def ot_has_small_bandgap(cp2k_input, cp2k_output, bandgap_thr_ev):
+    """ Returns True if the calculation used OT and had a smaller bandgap then the guess needed for the OT.
+    (NOTE: It has been observed also negative bandgap with OT in CP2K!)
+    cp2k_input: dict
+    cp2k_output: dict
+    bandgap_thr_ev: float [eV]
+    """
+    list_true = [True, 'T', 't', '.TRUE.', 'True', 'true']  #add more?
+    try:
+        ot_settings = cp2k_input['FORCE_EVAL']['DFT']['SCF']['OT']
+        if '_' not in ot_settings.keys() or ot_settings['_'] in list_true:  #pylint: disable=simplifiable-if-statement
+            using_ot = True
+        else:
+            using_ot = False
+    except KeyError:
+        using_ot = False
+    min_bandgap_ev = min(cp2k_output["bandgap_spin1_au"], cp2k_output["bandgap_spin2_au"]) * HARTREE2EV
+    is_bandgap_small = (min_bandgap_ev < bandgap_thr_ev)
+    return using_ot and is_bandgap_small

--- a/aiida_lsmo/utils/multiply_unitcell.py
+++ b/aiida_lsmo/utils/multiply_unitcell.py
@@ -1,5 +1,72 @@
-# -*- coding: utf-8 -*-
-"""Unit cell multiplication"""
+"""Utilities for unit cell multiplication, typically for cut-off issues."""
+
+from aiida.engine import calcfunction
+from aiida.orm import Dict, StructureData
+
+
+@calcfunction
+def check_resize_unit_cell_legacy(struct, threshold):  #pylint: disable=too-many-locals
+    """Returns the multiplication factors for the cell vectors to respect, in every direction:
+    min(perpendicular_width) > threshold.
+    TODO: this has been used for CP2K, make it uniform to the other one used for Raspa (from CifFile).
+    """
+    from math import cos, sin, sqrt, fabs, ceil
+    import numpy as np
+
+    # Parsing structure's cell
+    def angle(vect1, vect2):
+        return np.arccos(np.dot(vect1, vect2) / (np.linalg.norm(vect1) * np.linalg.norm(vect2)))
+
+    a_len = np.linalg.norm(struct.cell[0])
+    b_len = np.linalg.norm(struct.cell[1])
+    c_len = np.linalg.norm(struct.cell[2])
+
+    alpha = angle(struct.cell[1], struct.cell[2])
+    beta = angle(struct.cell[0], struct.cell[2])
+    gamma = angle(struct.cell[0], struct.cell[1])
+
+    # Computing triangular cell matrix
+    vol = np.sqrt(1 - cos(alpha)**2 - cos(beta)**2 - cos(gamma)**2 + 2 * cos(alpha) * cos(beta) * cos(gamma))
+    cell = np.zeros((3, 3))
+    cell[0, :] = [a_len, 0, 0]
+    cell[1, :] = [b_len * cos(gamma), b_len * sin(gamma), 0]
+    cell[2, :] = [
+        c_len * cos(beta), c_len * (cos(alpha) - cos(beta) * cos(gamma)) / (sin(gamma)), c_len * vol / sin(gamma)
+    ]
+    cell = np.array(cell)
+
+    # Computing perpendicular widths, as implemented in Raspa
+    # for the check (simplified for triangular cell matrix)
+    axc1 = cell[0, 0] * cell[2, 2]
+    axc2 = -cell[0, 0] * cell[2, 1]
+    bxc1 = cell[1, 1] * cell[2, 2]
+    bxc2 = -cell[1, 0] * cell[2, 2]
+    bxc3 = cell[1, 0] * cell[2, 1] - cell[1, 1] * cell[2, 0]
+    det = fabs(cell[0, 0] * cell[1, 1] * cell[2, 2])
+    perpwidth = np.zeros(3)
+    perpwidth[0] = det / sqrt(bxc1**2 + bxc2**2 + bxc3**2)
+    perpwidth[1] = det / sqrt(axc1**2 + axc2**2)
+    perpwidth[2] = cell[2, 2]
+
+    #prevent from crashing if threshold.value is zero
+    if threshold.value == 0:
+        thr = 0.1
+    else:
+        thr = threshold.value
+
+    resize = {
+        'nx': int(ceil(thr / perpwidth[0])),
+        'ny': int(ceil(thr / perpwidth[1])),
+        'nz': int(ceil(thr / perpwidth[2]))
+    }
+    return Dict(dict=resize)
+
+
+@calcfunction
+def resize_unit_cell(struct, resize):
+    """Resize the StructureData according to the resize Dict"""
+    resize_tuple = tuple([resize[x] for x in ['nx', 'ny', 'nz']])
+    return StructureData(ase=struct.get_ase().repeat(resize_tuple))
 
 
 def check_resize_unit_cell(cif, threshold):  #pylint: disable=too-many-locals

--- a/aiida_lsmo/utils/other_utilities.py
+++ b/aiida_lsmo/utils/other_utilities.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Other utilities"""
 
 from aiida.orm import Dict, CifData, StructureData
@@ -69,70 +68,6 @@ def aiida_structure_merge(aiida_structure_a, aiida_structure_b):
         positions=list(ase_a.positions) + list(ase_b.positions),
         pbc=True)
     return StructureData(ase=ase_ab)
-
-
-def get_kinds_with_ghost_section(structure, protocol_settings):
-    """Write the &KIND sections given the structure and the settings_dict, and add also GHOST atoms"""
-    kinds = []
-    all_atoms = set(structure.get_ase().get_chemical_symbols())
-    for atom in all_atoms:
-        kinds.append({
-            '_': atom,
-            'BASIS_SET': protocol_settings['basis_set'][atom],
-            'POTENTIAL': protocol_settings['pseudopotential'][atom],
-            'MAGNETIZATION': protocol_settings['initial_magnetization'][atom],
-        })
-        kinds.append({'_': atom + "_ghost", 'BASIS_SET': protocol_settings['basis_set'][atom], 'GHOST': True})
-    return {'FORCE_EVAL': {'SUBSYS': {'KIND': kinds}}}
-
-
-def get_bsse_section(natoms_a, natoms_b, mult_a=1, mult_b=1, charge_a=0, charge_b=0):
-    """Get the &FORCE_EVAL/&BSSE section."""
-    bsse_section = {
-        'FORCE_EVAL': {
-            'BSSE' : {
-                'FRAGMENT': [{
-                'LIST': '1..{}'.format(natoms_a)
-                },
-                {
-                'LIST': '{}..{}'.format(natoms_a + 1, natoms_a + natoms_b)
-                }],
-                'CONFIGURATION': [
-                    { # A fragment with basis set A
-                        'MULTIPLICITY': mult_a,
-                        'CHARGE': charge_a,
-                        'GLB_CONF': '1 0',
-                        'SUB_CONF': '1 0',
-                        },
-                    { # B fragment with basis set B
-                        'MULTIPLICITY': mult_b,
-                        'CHARGE': charge_b,
-                        'GLB_CONF': '0 1',
-                        'SUB_CONF': '0 1',
-                        },
-                    { # A fragment with basis set A+B
-                        'MULTIPLICITY': mult_a,
-                        'CHARGE': charge_a,
-                        'GLB_CONF': '1 1',
-                        'SUB_CONF': '1 0',
-                        },
-                    { # B fragment with basis set A+B
-                        'MULTIPLICITY': mult_b,
-                        'CHARGE': charge_b,
-                        'GLB_CONF': '1 1',
-                        'SUB_CONF': '0 1',
-                        },
-                    { # A+B fragments with basis set A+B
-                        'MULTIPLICITY': mult_a + mult_b - 1,
-                        'CHARGE': charge_a + charge_b,
-                        'GLB_CONF': '1 1',
-                        'SUB_CONF': '1 1',
-                        }
-                ]
-            }
-        }
-    }
-    return bsse_section
 
 
 @calcfunction

--- a/aiida_lsmo/workchains/__init__.py
+++ b/aiida_lsmo/workchains/__init__.py
@@ -1,10 +1,12 @@
 """Workchains developed at LSMO laboratory."""
+
 from .binding_site import BindingSiteWorkChain
 from .cp2k_binding_energy import Cp2kBindingEnergyWorkChain
+from .cp2k_multistage import Cp2kMultistageWorkChain
+from .cp2k_multistage_ddec import Cp2kMultistageDdecWorkChain
 from .isotherm import IsothermWorkChain
 from .isotherm_multi_temp import IsothermMultiTempWorkChain
 from .isotherm_calc_pe import IsothermCalcPEWorkChain
-from .multistage_ddec import MultistageDdecWorkChain
 from .sim_annealing import SimAnnealingWorkChain
 from .zeopp_multistage_ddec import ZeoppMultistageDdecWorkChain
 from .nanoporous_screening_1 import NanoporousScreening1WorkChain

--- a/aiida_lsmo/workchains/binding_site.py
+++ b/aiida_lsmo/workchains/binding_site.py
@@ -1,4 +1,4 @@
-"""MultistageDdecWorkChain workchain"""
+"""BindingSite workchain."""
 
 from aiida.plugins import DataFactory, WorkflowFactory
 from aiida.engine import WorkChain, ToContext

--- a/aiida_lsmo/workchains/binding_site.py
+++ b/aiida_lsmo/workchains/binding_site.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """MultistageDdecWorkChain workchain"""
 
 from aiida.plugins import DataFactory, WorkflowFactory

--- a/aiida_lsmo/workchains/cp2k_binding_energy.py
+++ b/aiida_lsmo/workchains/cp2k_binding_energy.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Binding energy workchain"""
 
 import os
@@ -12,8 +11,9 @@ from aiida.engine import calcfunction
 from aiida.orm import Dict, Int, SinglefileData, Str, StructureData
 from aiida.plugins import WorkflowFactory
 
-from aiida_cp2k.utils import HARTREE2EV, merge_dict, get_input_multiplicity, ot_has_small_bandgap
-from aiida_lsmo.utils import get_kinds_with_ghost_section, get_bsse_section, aiida_structure_merge
+from aiida_lsmo.utils import HARTREE2EV, dict_merge, aiida_structure_merge
+from aiida_lsmo.utils.cp2k_utils import get_input_multiplicity, ot_has_small_bandgap
+from aiida_lsmo.utils.cp2k_utils import get_kinds_with_ghost_section, get_bsse_section
 
 Cp2kBaseWorkChain = WorkflowFactory('cp2k.base')  # pylint: disable=invalid-name
 
@@ -124,7 +124,7 @@ class Cp2kBindingEnergyWorkChain(WorkChain):
             yamlfullpath = os.path.join(protocols_dir, self.inputs.protocol_tag.value + '.yaml')
             with open(yamlfullpath, 'r') as stream:
                 self.ctx.protocol = yaml.safe_load(stream)
-        merge_dict(self.ctx.protocol, self.inputs.protocol_modify.get_dict())
+        dict_merge(self.ctx.protocol, self.inputs.protocol_modify.get_dict())
 
         # Initialize
         self.ctx.settings_ok = False
@@ -142,12 +142,12 @@ class Cp2kBindingEnergyWorkChain(WorkChain):
             self.ctx.settings_idx += 1
             self.ctx.settings_tag = 'settings_{}'.format(self.ctx.settings_idx)
             if self.ctx.settings_tag in self.ctx.protocol:
-                merge_dict(self.ctx.cp2k_param, self.ctx.protocol[self.ctx.settings_tag])
+                dict_merge(self.ctx.cp2k_param, self.ctx.protocol[self.ctx.settings_tag])
             else:
                 return self.exit_codes.ERROR_MISSING_INITIAL_SETTINGS  # pylint: disable=no-member
-        merge_dict(self.ctx.cp2k_param, get_kinds_with_ghost_section(self.ctx.system, self.ctx.protocol))
-        merge_dict(self.ctx.cp2k_param, get_input_multiplicity(self.ctx.system, self.ctx.protocol))
-        merge_dict(
+        dict_merge(self.ctx.cp2k_param, get_kinds_with_ghost_section(self.ctx.system, self.ctx.protocol))
+        dict_merge(self.ctx.cp2k_param, get_input_multiplicity(self.ctx.system, self.ctx.protocol))
+        dict_merge(
             self.ctx.cp2k_param,
             {
                 'GLOBAL': {
@@ -184,7 +184,7 @@ class Cp2kBindingEnergyWorkChain(WorkChain):
 
         # Overwrite the generated input with the custom cp2k/parameters, update metadata and submit
         if 'parameters' in self.exposed_inputs(Cp2kBaseWorkChain, 'cp2k_base')['cp2k']:
-            merge_dict(self.ctx.cp2k_param,
+            dict_merge(self.ctx.cp2k_param,
                        self.exposed_inputs(Cp2kBaseWorkChain, 'cp2k_base')['cp2k']['parameters'].get_dict())
         self.ctx.base_inp['cp2k']['parameters'] = Dict(dict=self.ctx.cp2k_param)
         self.ctx.base_inp['metadata'].update({'label': 'geo_opt_molecule', 'call_link_label': 'run_geo_opt_molecule'})
@@ -228,7 +228,7 @@ class Cp2kBindingEnergyWorkChain(WorkChain):
             next_settings_tag = 'settings_{}'.format(self.ctx.settings_idx)
             if next_settings_tag in self.ctx.protocol:
                 self.ctx.settings_tag = next_settings_tag
-                merge_dict(self.ctx.cp2k_param, self.ctx.protocol[self.ctx.settings_tag])
+                dict_merge(self.ctx.cp2k_param, self.ctx.protocol[self.ctx.settings_tag])
             else:
                 return self.exit_codes.ERROR_NO_MORE_SETTINGS  # pylint: disable=no-member
 
@@ -238,7 +238,7 @@ class Cp2kBindingEnergyWorkChain(WorkChain):
         """
 
         self.ctx.cp2k_param['GLOBAL']['RUN_TYPE'] = 'BSSE'
-        merge_dict(
+        dict_merge(
             self.ctx.cp2k_param,
             get_bsse_section(natoms_a=self.ctx.natoms_structure,
                              natoms_b=self.ctx.natoms_molecule,
@@ -249,7 +249,7 @@ class Cp2kBindingEnergyWorkChain(WorkChain):
 
         # Overwrite the generated input with the custom cp2k/parameters, update structure and metadata, and submit
         if 'parameters' in self.exposed_inputs(Cp2kBaseWorkChain, 'cp2k_base')['cp2k']:
-            merge_dict(self.ctx.cp2k_param,
+            dict_merge(self.ctx.cp2k_param,
                        self.exposed_inputs(Cp2kBaseWorkChain, 'cp2k_base')['cp2k']['parameters'].get_dict())
         self.ctx.base_inp['cp2k']['parameters'] = Dict(dict=self.ctx.cp2k_param)
         self.ctx.base_inp['cp2k']['structure'] = self.ctx.stages[-1].outputs.output_structure

--- a/aiida_lsmo/workchains/cp2k_binding_energy.py
+++ b/aiida_lsmo/workchains/cp2k_binding_energy.py
@@ -189,7 +189,7 @@ class Cp2kBindingEnergyWorkChain(WorkChain):
         self.ctx.base_inp['cp2k']['parameters'] = Dict(dict=self.ctx.cp2k_param)
         self.ctx.base_inp['metadata'].update({'label': 'geo_opt_molecule', 'call_link_label': 'run_geo_opt_molecule'})
         self.ctx.base_inp['cp2k']['metadata'].update({'label': 'GEO_OPT'})
-        self.ctx.base_inp['cp2k']['metadata']['options']['parser_name'] = 'cp2k_advanced_parser'
+        self.ctx.base_inp['cp2k']['metadata']['options']['parser_name'] = 'lsmo.cp2k_advanced_parser'
         running_base = self.submit(Cp2kBaseWorkChain, **self.ctx.base_inp)
         self.report("Optimize molecule position in the structure.")
         return ToContext(stages=append_(running_base))
@@ -255,7 +255,7 @@ class Cp2kBindingEnergyWorkChain(WorkChain):
         self.ctx.base_inp['cp2k']['structure'] = self.ctx.stages[-1].outputs.output_structure
         self.ctx.base_inp['metadata'].update({'label': 'bsse', 'call_link_label': 'run_bsse'})
         self.ctx.base_inp['cp2k']['metadata'].update({'label': 'BSSE'})
-        self.ctx.base_inp['cp2k']['metadata']['options']['parser_name'] = 'cp2k_bsse_parser'
+        self.ctx.base_inp['cp2k']['metadata']['options']['parser_name'] = 'lsmo.cp2k_bsse_parser'
         running_base = self.submit(Cp2kBaseWorkChain, **self.ctx.base_inp)
         self.report("Run BSSE calculation to compute corrected binding energy.")
 

--- a/aiida_lsmo/workchains/cp2k_binding_energy.py
+++ b/aiida_lsmo/workchains/cp2k_binding_energy.py
@@ -3,7 +3,6 @@
 import os
 from copy import deepcopy
 import ruamel.yaml as yaml  # does not convert OFF to False
-import pkg_resources
 
 from aiida.common import AttributeDict
 from aiida.engine import append_, while_, WorkChain, ToContext
@@ -120,8 +119,8 @@ class Cp2kBindingEnergyWorkChain(WorkChain):
         if 'protocol_yaml' in self.inputs:
             self.ctx.protocol = yaml.safe_load(self.inputs.protocol_yaml.open())
         else:
-            protocols_dir = pkg_resources.resource_filename('aiida_cp2k', 'workchains/multistage_protocols')
-            yamlfullpath = os.path.join(protocols_dir, self.inputs.protocol_tag.value + '.yaml')
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            yamlfullpath = os.path.join(thisdir, 'cp2k_multistage_protocols', self.inputs.protocol_tag.value + '.yaml')
             with open(yamlfullpath, 'r') as stream:
                 self.ctx.protocol = yaml.safe_load(stream)
         dict_merge(self.ctx.protocol, self.inputs.protocol_modify.get_dict())

--- a/aiida_lsmo/workchains/cp2k_multistage.py
+++ b/aiida_lsmo/workchains/cp2k_multistage.py
@@ -1,0 +1,359 @@
+"""Multistage work chain."""
+
+import os
+from copy import deepcopy
+import ruamel.yaml as yaml  # does not convert OFF to False
+
+from aiida.common import AttributeDict
+from aiida.engine import append_, while_, WorkChain, ToContext
+from aiida.engine import calcfunction
+from aiida.orm import Dict, Int, Float, SinglefileData, Str, RemoteData, StructureData
+from aiida.plugins import WorkflowFactory
+from aiida_lsmo.utils import dict_merge, HARTREE2EV
+from aiida_lsmo.utils.multiply_unitcell import check_resize_unit_cell_legacy, resize_unit_cell
+from aiida_lsmo.utils.cp2k_utils import get_input_multiplicity, get_kinds_section, ot_has_small_bandgap
+
+Cp2kBaseWorkChain = WorkflowFactory('cp2k.base')  # pylint: disable=invalid-name
+
+
+@calcfunction
+def extract_results(resize, **kwargs):
+    """Extracts restults form the output_parameters of the single calculations (i.e., scf-converged stages)
+    into a single Dict output.
+    - resize (Dict) contains the unit cell resizing values
+    - kwargs contains all the output_parameters for the stages and the extra initial change of settings, e.g.:
+      'out_0': cp2k's output_parameters with Dict.label = 'settings_0_stage_0_discard'
+      'out_1': cp2k's output_parameters with Dict.label = 'settings_1_stage_0_valid'
+      'out_2': cp2k's output_parameters with Dict.label = 'settings_1_stage_0_valid'
+      'out_3': cp2k's output_parameters with Dict.label = 'settings_1_stage_0_valid'
+      This will be read as: output_dict = {'nstages_valid': 3, 'nsettings_discarded': 1}."""
+
+    output_dict = {}
+
+    # Sort the stages by key and cound the number of valid and descarded stages
+    sorted_values = [key_val[1] for key_val in sorted(kwargs.items(), key=lambda k: int(k[0][4:]))]
+    nstages_valid = sum(value.label.split('_')[-1] == 'valid' for value in sorted_values)
+    nsettings_discarded = len(sorted_values) - nstages_valid
+
+    # General info
+    output_dict['nstages_valid'] = nstages_valid
+    output_dict['nsettings_discarded'] = nsettings_discarded
+    output_dict['last_tag'] = sorted_values[-1].label.split()[-1]
+    output_dict['cell_resized'] = '{}x{}x{}'.format(resize['nx'], resize['ny'], resize['nz'])
+
+    # Create stage_info dictionary
+    output_dict['stage_info'] = {
+        'nsteps': [],
+        'opt_converged': [],
+        'final_edens_rspace': [],
+        'bandgap_spin1_au': [],
+        'bandgap_spin2_au': [],
+    }
+
+    # Create step_info dictionary
+    step_info_list = [
+        'step', 'energy_au', 'dispersion_energy_au', 'pressure_bar', 'cell_vol_angs3', 'cell_a_angs', 'cell_b_angs',
+        'cell_c_angs', 'cell_alp_deg', 'cell_bet_deg', 'cell_gam_deg', 'max_step_au', 'rms_step_au', 'max_grad_au',
+        'rms_grad_au', 'scf_converged'
+    ]
+    output_dict['step_info'] = {}
+    for step_info in step_info_list:
+        output_dict['step_info'][step_info] = []
+
+    # Fill stage_info and step_info with the results (skip all stage0 attempts with discarded settings)
+    for i in range(nsettings_discarded, len(kwargs)):  #
+        kwarg = kwargs['out_{}'.format(i)]
+        output_dict['stage_info']['nsteps'].append(kwarg['motion_step_info']['step'][-1])
+        output_dict['stage_info']['opt_converged'].append(kwarg['motion_opt_converged'])
+        output_dict['stage_info']['final_edens_rspace'].append(kwarg['motion_step_info']['edens_rspace'][-1])
+        output_dict['stage_info']['bandgap_spin1_au'].append(kwarg['bandgap_spin1_au'])
+        output_dict['stage_info']['bandgap_spin2_au'].append(kwarg['bandgap_spin1_au'])
+        for istep, step in enumerate(kwarg['motion_step_info']['step']):
+            # Exclude redoundant zeroth calculations but remember that LBFGS starts from 1:
+            # i.e., print when it is the first entry OR not first entry but step>0
+            if not (step == 0 and output_dict['step_info']['step']):
+                for step_info in step_info_list:
+                    output_dict['step_info'][step_info].append(kwarg['motion_step_info'][step_info][istep])
+
+    # Outputs from the last stage only
+    output_dict['natoms'] = kwarg['natoms']
+    output_dict['dft_type'] = kwarg['dft_type']
+    output_dict['final_bandgap_spin1_au'] = kwarg['bandgap_spin1_au']
+    output_dict['final_bandgap_spin2_au'] = kwarg['bandgap_spin2_au']
+
+    return Dict(dict=output_dict)
+
+
+class Cp2kMultistageWorkChain(WorkChain):
+    """Submits Cp2kBase workchains for ENERGY, GEO_OPT, CELL_OPT and MD jobs iteratively
+
+    The protocol_yaml file contains a series of settings_x and stage_x:
+    the workchains starts running the settings_0/stage_0 calculation, and, in case of a failure, changes the settings
+    untill the SCF of stage_0 converges. Then it uses the same settings to run the next stages (i.e., stage_1, etc.)."""
+
+    @classmethod
+    def define(cls, spec):
+        super(Cp2kMultistageWorkChain, cls).define(spec)
+
+        # Inputs
+        spec.expose_inputs(Cp2kBaseWorkChain,
+                           namespace='cp2k_base',
+                           exclude=['cp2k.structure', 'cp2k.parameters', 'cp2k.metadata.options.parser_name'])
+        spec.input('structure', valid_type=StructureData, required=False, help='Input structure')
+        spec.input('protocol_tag',
+                   valid_type=Str,
+                   default=lambda: Str('standard'),
+                   required=False,
+                   help='The tag of the protocol to be read from {tag}.yaml unless protocol_yaml input is specified')
+        spec.input('protocol_yaml',
+                   valid_type=SinglefileData,
+                   required=False,
+                   help='Specify a custom yaml file with the multistage settings (and ignore protocol_tag)')
+        spec.input('protocol_modify',
+                   valid_type=Dict,
+                   default=lambda: Dict(dict={}),
+                   required=False,
+                   help='Specify custom settings that overvrite the yaml settings')
+        spec.input('starting_settings_idx',
+                   valid_type=Int,
+                   default=lambda: Int(0),
+                   required=False,
+                   help='If idx>0 is chosen, jumps directly to overwrite settings_0 with settings_{idx}')
+        spec.input('min_cell_size',
+                   valid_type=Float,
+                   default=lambda: Float(0.0),
+                   required=False,
+                   help='To avoid using k-points, extend the cell so that min(perp_width)>min_cell_size')
+        spec.input('parent_calc_folder',
+                   valid_type=RemoteData,
+                   required=False,
+                   help='Provide an initial parent folder that contains the wavefunction for restart')
+        spec.input(
+            'cp2k_base.cp2k.parameters',
+            valid_type=Dict,
+            required=False,
+            help='Specify custom CP2K settings to overwrite the input dictionary just before submitting the CalcJob')
+        spec.input('cp2k_base.cp2k.metadata.options.parser_name',
+                   valid_type=str,
+                   default='cp2k_advanced_parser',
+                   non_db=True,
+                   help='Parser of the calculation: the default is cp2k_advanced_parser to get the necessary info')
+
+        # Workchain outline
+        spec.outline(
+            cls.setup_multistage,
+            while_(cls.should_run_stage0)(
+                cls.run_stage,
+                cls.inspect_and_update_settings_stage0,
+            ),
+            cls.inspect_and_update_stage,
+            while_(cls.should_run_stage)(
+                cls.run_stage,
+                cls.inspect_and_update_stage,
+            ),
+            cls.results,
+        )
+
+        # Exit codes
+        spec.exit_code(901, 'ERROR_MISSING_INITIAL_SETTINGS',
+                       'Specified starting_settings_idx that is not existing, or any in between 0 and idx is missing')
+        spec.exit_code(902, 'ERROR_NO_MORE_SETTINGS',
+                       'Settings for Stage0 are not ok but there are no more robust settings to try')
+        spec.exit_code(903, 'ERROR_PARSING_OUTPUT',
+                       'Something important was not printed correctly and the parsing of the first calculation failed')
+
+        # Outputs
+        spec.expose_outputs(Cp2kBaseWorkChain, include=['remote_folder'])
+        spec.output('output_structure',
+                    valid_type=StructureData,
+                    required=False,
+                    help='Processed structure (missing if only ENERGY calculation is performed)')
+        spec.output('last_input_parameters',
+                    valid_type=Dict,
+                    required=False,
+                    help='CP2K input parameters used (and possibly working) used in the last stage')
+        spec.output('output_parameters',
+                    valid_type=Dict,
+                    required=False,
+                    help='Output CP2K parameters of all the stages, merged together')
+
+    def setup_multistage(self):
+        """Setup initial parameters."""
+
+        # Store the workchain inputs in context (to be modified later)
+        self.ctx.base_inp = AttributeDict(self.exposed_inputs(Cp2kBaseWorkChain, 'cp2k_base'))
+
+        # Check if an input parent_calc_folder is provided
+        if 'parent_calc_folder' in self.inputs:
+            self.ctx.parent_calc_folder = self.inputs.parent_calc_folder
+        else:
+            self.ctx.parent_calc_folder = None
+
+        # Read yaml file selected as SinglefileData or chosen with the tag, and overwrite with custom modifications
+        if 'protocol_yaml' in self.inputs:
+            self.ctx.protocol = yaml.safe_load(self.inputs.protocol_yaml.open())
+        else:
+            thisdir = os.path.dirname(os.path.abspath(__file__))
+            yamlfullpath = os.path.join(thisdir, 'multistage_protocols', self.inputs.protocol_tag.value + '.yaml')
+            with open(yamlfullpath, 'r') as stream:
+                self.ctx.protocol = yaml.safe_load(stream)
+        dict_merge(self.ctx.protocol, self.inputs.protocol_modify.get_dict())
+
+        # Initialize
+        self.ctx.settings_ok = False
+        self.ctx.stage_idx = 0
+        self.ctx.stage_tag = 'stage_{}'.format(self.ctx.stage_idx)
+        self.ctx.settings_idx = 0
+        self.ctx.settings_tag = 'settings_{}'.format(self.ctx.settings_idx)
+        self.ctx.structure = self.inputs.structure
+
+        # Resize the unit cell if min(perp_with) < inputs.min_cell_size
+        self.ctx.resize = check_resize_unit_cell_legacy(self.ctx.structure, self.inputs.min_cell_size)  # Dict
+        if self.ctx.resize['nx'] > 1 or self.ctx.resize['ny'] > 1 or self.ctx.resize['nz'] > 1:
+            resized_struct = resize_unit_cell(self.ctx.structure, self.ctx.resize)
+            self.ctx.structure = resized_struct
+            self.report("Unit cell resized by {}x{}x{} (StructureData<{}>)".format(self.ctx.resize['nx'],
+                                                                                   self.ctx.resize['ny'],
+                                                                                   self.ctx.resize['nz'],
+                                                                                   resized_struct.pk))
+        else:
+            self.report("Unit cell was NOT resized")
+
+        # Generate input parameters and store them
+        self.ctx.cp2k_param = deepcopy(self.ctx.protocol['settings_0'])
+        while self.inputs.starting_settings_idx < self.ctx.settings_idx:
+            # overwrite untill the desired starting setting are obtained
+            self.ctx.settings_idx += 1
+            self.ctx.settings_tag = 'settings_{}'.format(self.ctx.settings_idx)
+            if self.ctx.settings_tag in self.ctx.protocol:
+                dict_merge(self.ctx.cp2k_param, self.ctx.protocol[self.ctx.settings_tag])
+            else:
+                return self.exit_codes.ERROR_MISSING_INITIAL_SETTINGS  # pylint: disable=no-member
+        kinds = get_kinds_section(self.ctx.structure, self.ctx.protocol)
+        dict_merge(self.ctx.cp2k_param, kinds)
+        multiplicity = get_input_multiplicity(self.ctx.structure, self.ctx.protocol)
+        dict_merge(self.ctx.cp2k_param, multiplicity)
+        dict_merge(self.ctx.cp2k_param, self.ctx.protocol['stage_0'])
+
+    def should_run_stage0(self):
+        """Returns True if it is the first iteration or the settings are not ok."""
+        return not self.ctx.settings_ok
+
+    def run_stage(self):
+        """Check for restart, prepare input, submit and direct output to context."""
+
+        # Update structure
+        self.ctx.base_inp['cp2k']['structure'] = self.ctx.structure
+
+        # Check if it is needed to restart the calculation and provide the parent folder and new structure
+        if self.ctx.parent_calc_folder:
+            self.ctx.base_inp['cp2k']['parent_calc_folder'] = self.ctx.parent_calc_folder
+            self.ctx.cp2k_param['FORCE_EVAL']['DFT']['SCF']['SCF_GUESS'] = 'RESTART'
+            self.ctx.cp2k_param['FORCE_EVAL']['DFT']['WFN_RESTART_FILE_NAME'] = './parent_calc/aiida-RESTART.wfn'
+        else:
+            self.ctx.cp2k_param['FORCE_EVAL']['DFT']['SCF']['SCF_GUESS'] = 'ATOMIC'
+
+        # Overwrite the generated input with the custom cp2k/parameters
+        if 'parameters' in self.exposed_inputs(Cp2kBaseWorkChain, 'cp2k_base')['cp2k']:
+            dict_merge(
+                self.ctx.cp2k_param,
+                AttributeDict(self.exposed_inputs(Cp2kBaseWorkChain, 'cp2k_base')['cp2k']['parameters'].get_dict()))
+        self.ctx.base_inp['cp2k']['parameters'] = Dict(dict=self.ctx.cp2k_param).store()
+
+        # Update labels
+        self.ctx.base_inp['metadata'].update({
+            'label': '{}_{}'.format(self.ctx.stage_tag, self.ctx.settings_tag),
+            'call_link_label': 'run_{}_{}'.format(self.ctx.stage_tag, self.ctx.settings_tag),
+        })
+        self.ctx.base_inp['cp2k']['metadata'].update(
+            {'label': self.ctx.base_inp['cp2k']['parameters'].get_dict()['GLOBAL']['RUN_TYPE']})
+
+        running_base = self.submit(Cp2kBaseWorkChain, **self.ctx.base_inp)
+        self.report("submitted Cp2kBaseWorkChain for {}/{}".format(self.ctx.stage_tag, self.ctx.settings_tag))
+        return ToContext(stages=append_(running_base))
+
+    def inspect_and_update_settings_stage0(self):  # pylint: disable=inconsistent-return-statements
+        """Inspect the stage0/settings_{idx} calculation and check if it is
+        needed to update the settings and resubmint the calculation."""
+        self.ctx.settings_ok = True
+
+        # Settings/structure are bad: there are problems in parsing the output file
+        # and, most probably, the calculation didn't even start the scf cycles
+        if 'output_parameters' in self.ctx.stages[-1].outputs:
+            cp2k_out = self.ctx.stages[-1].outputs.output_parameters
+        else:
+            self.report('ERROR_PARSING_OUTPUT')
+            return self.exit_codes.ERROR_PARSING_OUTPUT  # pylint: disable=no-member
+
+        # Settings are bad: the SCF did not converge in the final step
+        if not cp2k_out["motion_step_info"]["scf_converged"][-1]:
+            self.report("BAD SETTINGS: the SCF did not converge")
+            self.ctx.settings_ok = False
+            self.ctx.settings_idx += 1
+        else:
+            # SCF converged, but the computed bandgap needs to be checked
+            self.report("Bandgaps spin1/spin2: {:.3f} and {:.3f} ev".format(cp2k_out["bandgap_spin1_au"] * HARTREE2EV,
+                                                                            cp2k_out["bandgap_spin2_au"] * HARTREE2EV))
+            bandgap_thr_ev = self.ctx.protocol['bandgap_thr_ev']
+            if ot_has_small_bandgap(self.ctx.cp2k_param, cp2k_out, bandgap_thr_ev):
+                self.report("BAD SETTINGS: band gap is < {:.3f} eV".format(bandgap_thr_ev))
+                self.ctx.settings_ok = False
+                self.ctx.settings_idx += 1
+
+        # Update the settings tag, check if it is available and overwrite
+        if not self.ctx.settings_ok:
+            cp2k_out.label = '{}_{}_discard'.format(self.ctx.stage_tag, self.ctx.settings_tag)
+            next_settings_tag = 'settings_{}'.format(self.ctx.settings_idx)
+            if next_settings_tag in self.ctx.protocol:
+                self.ctx.settings_tag = next_settings_tag
+                dict_merge(self.ctx.cp2k_param, self.ctx.protocol[self.ctx.settings_tag])
+            else:
+                return self.exit_codes.ERROR_NO_MORE_SETTINGS  # pylint: disable=no-member
+
+    def inspect_and_update_stage(self):
+        """Update geometry, parent folder and the new &MOTION settings."""
+        last_stage = self.ctx.stages[-1]
+
+        if 'output_structure' in last_stage.outputs:
+            self.ctx.structure = last_stage.outputs.output_structure
+            self.report('Structure updated for next stage')
+        else:
+            self.report('New structure NOT found and NOT updated for next stage')
+
+        self.ctx.parent_calc_folder = last_stage.outputs.remote_folder
+        last_stage.outputs.output_parameters.label = '{}_{}_valid'.format(self.ctx.stage_tag, self.ctx.settings_tag)
+
+        self.ctx.stage_idx += 1
+        next_stage_tag = 'stage_{}'.format(self.ctx.stage_idx)
+
+        if next_stage_tag in self.ctx.protocol:
+            self.ctx.stage_tag = next_stage_tag
+            self.ctx.next_stage_exists = True
+            dict_merge(self.ctx.cp2k_param, self.ctx.protocol[self.ctx.stage_tag])
+        else:
+            self.ctx.next_stage_exists = False
+            self.report("All stages computed, finishing...")
+
+    def should_run_stage(self):
+        """Return True if it exists a new stage to compute."""
+        return self.ctx.next_stage_exists
+
+    def results(self):
+        """Gather final outputs of the workchain."""
+
+        # Gather all the ouput_parameters in a final Dict
+        all_output_parameters = {}
+        for i, stage in enumerate(self.ctx.stages):
+            all_output_parameters['out_{}'.format(i)] = stage.outputs.output_parameters
+        self.out('output_parameters', extract_results(resize=self.ctx.resize, **all_output_parameters))
+        # Output the final parameters that worked as a Dict
+        self.out('last_input_parameters', self.ctx.base_inp['cp2k']['parameters'])
+        # Output the final remote folder
+        self.out_many(self.exposed_outputs(self.ctx.stages[-1], Cp2kBaseWorkChain))
+        # Output the final structure only if it was modified (there is any MD or OPT stage)
+        if 'output_structure' in self.ctx.stages[-1].outputs:
+            self.out('output_structure', self.ctx.stages[-1].outputs.output_structure)
+            self.report("Outputs: Dict<{}> and StructureData<{}>".format(self.outputs['output_parameters'].pk,
+                                                                         self.outputs['output_structure'].pk))
+        else:
+            self.report("Outputs: Dict<{}> and NO StructureData".format(self.outputs['output_parameters'].pk))

--- a/aiida_lsmo/workchains/cp2k_multistage.py
+++ b/aiida_lsmo/workchains/cp2k_multistage.py
@@ -93,7 +93,7 @@ class Cp2kMultistageWorkChain(WorkChain):
 
     @classmethod
     def define(cls, spec):
-        super(Cp2kMultistageWorkChain, cls).define(spec)
+        super().define(spec)
 
         # Inputs
         spec.expose_inputs(Cp2kBaseWorkChain,
@@ -194,7 +194,7 @@ class Cp2kMultistageWorkChain(WorkChain):
             self.ctx.protocol = yaml.safe_load(self.inputs.protocol_yaml.open())
         else:
             thisdir = os.path.dirname(os.path.abspath(__file__))
-            yamlfullpath = os.path.join(thisdir, 'multistage_protocols', self.inputs.protocol_tag.value + '.yaml')
+            yamlfullpath = os.path.join(thisdir, 'cp2k_multistage_protocols', self.inputs.protocol_tag.value + '.yaml')
             with open(yamlfullpath, 'r') as stream:
                 self.ctx.protocol = yaml.safe_load(stream)
         dict_merge(self.ctx.protocol, self.inputs.protocol_modify.get_dict())

--- a/aiida_lsmo/workchains/cp2k_multistage.py
+++ b/aiida_lsmo/workchains/cp2k_multistage.py
@@ -22,11 +22,12 @@ def extract_results(resize, **kwargs):
     into a single Dict output.
     - resize (Dict) contains the unit cell resizing values
     - kwargs contains all the output_parameters for the stages and the extra initial change of settings, e.g.:
-      'out_0': cp2k's output_parameters with Dict.label = 'settings_0_stage_0_discard'
-      'out_1': cp2k's output_parameters with Dict.label = 'settings_1_stage_0_valid'
-      'out_2': cp2k's output_parameters with Dict.label = 'settings_1_stage_0_valid'
-      'out_3': cp2k's output_parameters with Dict.label = 'settings_1_stage_0_valid'
-      This will be read as: output_dict = {'nstages_valid': 3, 'nsettings_discarded': 1}."""
+    'out_0': cp2k's output_parameters with Dict.label = 'settings_0_stage_0_discard'
+    'out_1': cp2k's output_parameters with Dict.label = 'settings_1_stage_0_valid'
+    'out_2': cp2k's output_parameters with Dict.label = 'settings_1_stage_0_valid'
+    'out_3': cp2k's output_parameters with Dict.label = 'settings_1_stage_0_valid'
+    This will be read as: output_dict = {'nstages_valid': 3, 'nsettings_discarded': 1}.
+    """
 
     output_dict = {}
 
@@ -86,10 +87,10 @@ def extract_results(resize, **kwargs):
 
 class Cp2kMultistageWorkChain(WorkChain):
     """Submits Cp2kBase workchains for ENERGY, GEO_OPT, CELL_OPT and MD jobs iteratively
-
     The protocol_yaml file contains a series of settings_x and stage_x:
     the workchains starts running the settings_0/stage_0 calculation, and, in case of a failure, changes the settings
-    untill the SCF of stage_0 converges. Then it uses the same settings to run the next stages (i.e., stage_1, etc.)."""
+    untill the SCF of stage_0 converges. Then it uses the same settings to run the next stages (i.e., stage_1, etc.).
+    """
 
     @classmethod
     def define(cls, spec):

--- a/aiida_lsmo/workchains/cp2k_multistage.py
+++ b/aiida_lsmo/workchains/cp2k_multistage.py
@@ -222,7 +222,7 @@ class Cp2kMultistageWorkChain(WorkChain):
 
         # Generate input parameters and store them
         self.ctx.cp2k_param = deepcopy(self.ctx.protocol['settings_0'])
-        while self.inputs.starting_settings_idx < self.ctx.settings_idx:
+        while self.inputs.starting_settings_idx > self.ctx.settings_idx:
             # overwrite untill the desired starting setting are obtained
             self.ctx.settings_idx += 1
             self.ctx.settings_tag = 'settings_{}'.format(self.ctx.settings_idx)

--- a/aiida_lsmo/workchains/cp2k_multistage.py
+++ b/aiida_lsmo/workchains/cp2k_multistage.py
@@ -136,7 +136,7 @@ class Cp2kMultistageWorkChain(WorkChain):
             help='Specify custom CP2K settings to overwrite the input dictionary just before submitting the CalcJob')
         spec.input('cp2k_base.cp2k.metadata.options.parser_name',
                    valid_type=str,
-                   default='cp2k_advanced_parser',
+                   default='lsmo.cp2k_advanced_parser',
                    non_db=True,
                    help='Parser of the calculation: the default is cp2k_advanced_parser to get the necessary info')
 

--- a/aiida_lsmo/workchains/cp2k_multistage_ddec.py
+++ b/aiida_lsmo/workchains/cp2k_multistage_ddec.py
@@ -1,4 +1,4 @@
-"""MultistageDdecWorkChain workchain"""
+"""Cp2kMultistageDdecWorkChain workchain"""
 
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory
 from aiida.common import AttributeDict
@@ -6,7 +6,7 @@ from aiida.engine import WorkChain, ToContext
 from aiida_lsmo.utils import aiida_dict_merge
 
 # import sub-workchains
-Cp2kMultistageWorkChain = WorkflowFactory('cp2k.multistage')  # pylint: disable=invalid-name
+Cp2kMultistageWorkChain = WorkflowFactory('lsmo.cp2k_multistage')  # pylint: disable=invalid-name
 Cp2kDdecWorkChain = WorkflowFactory('ddec.cp2k_ddec')  # pylint: disable=invalid-name
 
 # import calculations
@@ -17,7 +17,7 @@ Dict = DataFactory('dict')  # pylint: disable=invalid-name
 CifData = DataFactory('cif')  # pylint: disable=invalid-name
 
 
-class MultistageDdecWorkChain(WorkChain):
+class Cp2kMultistageDdecWorkChain(WorkChain):
     """A workchain that combines: Cp2kMultistageWorkChain + Cp2kDdecWorkChain"""
 
     @classmethod

--- a/aiida_lsmo/workchains/cp2k_multistage_protocols/robust_conv.yaml
+++ b/aiida_lsmo/workchains/cp2k_multistage_protocols/robust_conv.yaml
@@ -1,0 +1,372 @@
+protocol_description: >
+  Protocol conceived for materials for which the SCF is difficult to converge.
+  Compared to the standard protocol, this has more OT-CG max iter,
+  and more DIAGONALIZATION+SMEAR max iter, with lower MIXING ALPHA.
+  The NPT-MD step is removed because this calculation is typically too expensive for it.
+
+# Defining atomic properties
+
+initial_magnetization:
+  H:  0
+  Li: 0  # oxidation state +1
+  Be: 0  # oxidation state +2
+  B:  0
+  C:  0
+  N:  0
+  O:  0
+  F:  0
+  Na: 0  # oxidation state +1
+  Mg: 0  # oxidation state +2
+  Al: 0  # oxidation state +3
+  Si: 0
+  P:  0
+  S:  0
+  Cl: 0
+  K:  0  # oxidation state +1
+  Ca: 0  # oxidation state +2
+  Sc: 0  # oxidation state +1
+  Ti: 0  # oxidation state +4
+  V:  3  # oxidation state +2 high spin
+  Cr: 4  # oxidation state +2 high spin
+  Mn: 5  # oxidation state +2 high spin
+  Fe: 4  # oxidation state +2 high spin
+  Co: 3  # oxidation state +2 high spin
+  Ni: 2  # oxidation state +2 high spin
+  Cu: 1  # oxidation state +2 high spin
+  Zn: 0  # oxidation state +2
+  Zr: 0  # oxidation state +4
+
+basis_set:
+  H:  DZVP-MOLOPT-SR-GTH-q1
+  He: DZVP-MOLOPT-SR-GTH-q2
+  Li: DZVP-MOLOPT-SR-GTH-q3
+  Be: DZVP-MOLOPT-SR-GTH-q4
+  B:  DZVP-MOLOPT-SR-GTH-q3
+  C:  DZVP-MOLOPT-SR-GTH-q4
+  N:  DZVP-MOLOPT-SR-GTH-q5
+  O:  DZVP-MOLOPT-SR-GTH-q6
+  F:  DZVP-MOLOPT-SR-GTH-q7
+  Ne: DZVP-MOLOPT-SR-GTH-q8
+  Na: DZVP-MOLOPT-SR-GTH-q9
+  Mg: DZVP-MOLOPT-SR-GTH-q2
+  Al: DZVP-MOLOPT-SR-GTH-q3
+  Si: DZVP-MOLOPT-SR-GTH-q4
+  P:  DZVP-MOLOPT-SR-GTH-q5
+  S:  DZVP-MOLOPT-SR-GTH-q6
+  Cl: DZVP-MOLOPT-SR-GTH-q7
+  Ar: DZVP-MOLOPT-SR-GTH-q8
+  K:  DZVP-MOLOPT-SR-GTH-q9
+  Ca: DZVP-MOLOPT-SR-GTH-q10
+  Sc: DZVP-MOLOPT-SR-GTH-q11
+  Ti: DZVP-MOLOPT-SR-GTH-q12
+  V:  DZVP-MOLOPT-SR-GTH-q13
+  Cr: DZVP-MOLOPT-SR-GTH-q14
+  Mn: DZVP-MOLOPT-SR-GTH-q15
+  Fe: DZVP-MOLOPT-SR-GTH-q16
+  Co: DZVP-MOLOPT-SR-GTH-q17
+  Ni: DZVP-MOLOPT-SR-GTH-q18
+  Cu: DZVP-MOLOPT-SR-GTH-q11
+  Zn: DZVP-MOLOPT-SR-GTH-q12
+  Ga: DZVP-MOLOPT-SR-GTH-q13
+  Ge: DZVP-MOLOPT-SR-GTH-q4
+  As: DZVP-MOLOPT-SR-GTH-q5
+  Se: DZVP-MOLOPT-SR-GTH-q6
+  Br: DZVP-MOLOPT-SR-GTH-q7
+  Kr: DZVP-MOLOPT-SR-GTH-q8
+  Rb: DZVP-MOLOPT-SR-GTH-q9
+  Sr: DZVP-MOLOPT-SR-GTH-q10
+  Y:  DZVP-MOLOPT-SR-GTH-q11
+  Zr: DZVP-MOLOPT-SR-GTH-q12
+  Nb: DZVP-MOLOPT-SR-GTH-q13
+  Mo: DZVP-MOLOPT-SR-GTH-q14
+  Tc: DZVP-MOLOPT-SR-GTH-q15
+  Ru: DZVP-MOLOPT-SR-GTH-q16
+  Rh: DZVP-MOLOPT-SR-GTH-q9
+  Pd: DZVP-MOLOPT-SR-GTH-q18
+  Ag: DZVP-MOLOPT-SR-GTH-q11
+  Cd: DZVP-MOLOPT-SR-GTH-q12
+  In: DZVP-MOLOPT-SR-GTH-q13
+  Sn: DZVP-MOLOPT-SR-GTH-q4
+  Sb: DZVP-MOLOPT-SR-GTH-q5
+  Te: DZVP-MOLOPT-SR-GTH-q6
+  I:  DZVP-MOLOPT-SR-GTH-q7
+  Xe: DZVP-MOLOPT-SR-GTH-q8
+  Cs: DZVP-MOLOPT-SR-GTH-q9
+  Ba: DZVP-MOLOPT-SR-GTH-q10
+  La: DZVP-MOLOPT-SR-GTH-q11
+  Ce: DZVP-MOLOPT-SR-GTH-q12
+  Pr: DZVP-MOLOPT-SR-GTH-q13
+  Nd: DZVP-MOLOPT-SR-GTH-q14
+  Pm: DZVP-MOLOPT-SR-GTH-q15
+  Sm: DZVP-MOLOPT-SR-GTH-q16
+  Eu: DZVP-MOLOPT-SR-GTH-q17
+  Gd: DZVP-MOLOPT-SR-GTH-q18
+  Tb: DZVP-MOLOPT-SR-GTH-q19
+  Dy: DZVP-MOLOPT-SR-GTH-q20
+  Ho: DZVP-MOLOPT-SR-GTH-q21
+  Er: DZVP-MOLOPT-SR-GTH-q22
+  Tm: DZVP-MOLOPT-SR-GTH-q23
+  Yb: DZVP-MOLOPT-SR-GTH-q24
+  Lu: DZVP-MOLOPT-SR-GTH-q25
+  Hf: DZVP-MOLOPT-SR-GTH-q12
+  Ta: DZVP-MOLOPT-SR-GTH-q13
+  W:  DZVP-MOLOPT-SR-GTH-q14
+  Re: DZVP-MOLOPT-SR-GTH-q15
+  Os: DZVP-MOLOPT-SR-GTH-q16
+  Ir: DZVP-MOLOPT-SR-GTH-q17
+  Pt: DZVP-MOLOPT-SR-GTH-q18
+  Au: DZVP-MOLOPT-SR-GTH-q11
+  Hg: DZVP-MOLOPT-SR-GTH-q12
+  Tl: DZVP-MOLOPT-SR-GTH-q13
+  Pb: DZVP-MOLOPT-SR-GTH-q4
+  Bi: DZVP-MOLOPT-SR-GTH-q5
+  Po: DZVP-MOLOPT-SR-GTH-q6
+  At: DZVP-MOLOPT-SR-GTH-q7
+  Rn: DZVP-MOLOPT-SR-GTH-q8
+
+pseudopotential:
+   H:  GTH-PBE-q1
+   He: GTH-PBE-q2
+   Li: GTH-PBE-q3
+   Be: GTH-PBE-q4
+   B:  GTH-PBE-q3
+   C:  GTH-PBE-q4
+   N:  GTH-PBE-q5
+   O:  GTH-PBE-q6
+   F:  GTH-PBE-q7
+   Ne: GTH-PBE-q8
+   Na: GTH-PBE-q9
+   Mg: GTH-PBE-q2
+   Al: GTH-PBE-q3
+   Si: GTH-PBE-q4
+   P:  GTH-PBE-q5
+   S:  GTH-PBE-q6
+   Cl: GTH-PBE-q7
+   Ar: GTH-PBE-q8
+   K:  GTH-PBE-q9
+   Ca: GTH-PBE-q10
+   Sc: GTH-PBE-q11
+   Ti: GTH-PBE-q12
+   V:  GTH-PBE-q13
+   Cr: GTH-PBE-q14
+   Mn: GTH-PBE-q15
+   Fe: GTH-PBE-q16
+   Co: GTH-PBE-q17
+   Ni: GTH-PBE-q18
+   Cu: GTH-PBE-q11
+   Zn: GTH-PBE-q12
+   Ga: GTH-PBE-q13
+   Ge: GTH-PBE-q4
+   As: GTH-PBE-q5
+   Se: GTH-PBE-q6
+   Br: GTH-PBE-q7
+   Kr: GTH-PBE-q8
+   Rb: GTH-PBE-q9
+   Sr: GTH-PBE-q10
+   Y:  GTH-PBE-q11
+   Zr: GTH-PBE-q12
+   Nb: GTH-PBE-q13
+   Mo: GTH-PBE-q14
+   Tc: GTH-PBE-q15
+   Ru: GTH-PBE-q16
+   Rh: GTH-PBE-q9
+   Pd: GTH-PBE-q18
+   Ag: GTH-PBE-q11
+   Cd: GTH-PBE-q12
+   In: GTH-PBE-q13
+   Sn: GTH-PBE-q4
+   Sb: GTH-PBE-q5
+   Te: GTH-PBE-q6
+   I:  GTH-PBE-q7
+   Xe: GTH-PBE-q8
+   Cs: GTH-PBE-q9
+   Ba: GTH-PBE-q10
+   La: GTH-PBE-q11
+   Ce: GTH-PBE-q12
+   Pr: GTH-PBE-q13
+   Nd: GTH-PBE-q14
+   Pm: GTH-PBE-q15
+   Sm: GTH-PBE-q16
+   Eu: GTH-PBE-q17
+   Gd: GTH-PBE-q18
+   Tb: GTH-PBE-q19
+   Dy: GTH-PBE-q20
+   Ho: GTH-PBE-q21
+   Er: GTH-PBE-q22
+   Tm: GTH-PBE-q23
+   Yb: GTH-PBE-q24
+   Lu: GTH-PBE-q25
+   Hf: GTH-PBE-q12
+   Ta: GTH-PBE-q13
+   W:  GTH-PBE-q14
+   Re: GTH-PBE-q15
+   Os: GTH-PBE-q16
+   Ir: GTH-PBE-q17
+   Pt: GTH-PBE-q18
+   Au: GTH-PBE-q11
+   Hg: GTH-PBE-q12
+   Tl: GTH-PBE-q13
+   Pb: GTH-PBE-q4
+   Bi: GTH-PBE-q5
+   Po: GTH-PBE-q6
+   At: GTH-PBE-q7
+   Rn: GTH-PBE-q8
+
+# Defining input settings
+bandgap_thr_ev: 0.0 #bandgap threshold minimum under which the OT is not considered as valid (ROBUST: > 0.0 is fine!)
+
+settings_0: # main settings exploiting OT
+  GLOBAL:
+    PRINT_LEVEL: MEDIUM              #default: MEDIUM. Important to have the correct parsing
+  FORCE_EVAL:
+    METHOD:         QUICKSTEP
+    STRESS_TENSOR:  ANALYTICAL
+    DFT:
+      BASIS_SET_FILE_NAME:
+        - BASIS_MOLOPT
+        - BASIS_MOLOPT_UCL
+      POTENTIAL_FILE_NAME:
+        -  GTH_POTENTIALS
+      UKS:          False
+      CHARGE:       0
+      MULTIPLICITY: 0
+      MGRID:
+        CUTOFF:      600
+        REL_CUTOFF:  50
+        NGRIDS:      4
+      QS:
+        METHOD: GPW
+        EPS_DEFAULT:   1.0E-10
+        EXTRAPOLATION: ASPC
+
+      SCF:
+        MAX_SCF:       300           # ROBUST: optimum compromise
+        EPS_SCF:       1.0E-6        # ROBUST: Looser than the standard protocol for an easy convergence
+        MAX_ITER_LUMO: 10000         # for computing the Band gap
+        OUTER_SCF:
+          MAX_SCF:   10              # ROBUST: more than the Standard protocol
+          EPS_SCF:   1.0E-6          # ROBUST: equal (or smaller for expert use) than SCF/EPS_SCF
+        OT:
+          PRECONDITIONER: FULL_KINETIC # ROBUST: usually working better for difficult cases
+          MINIMIZER:      CG           # ROBUST: more robust than DIIS
+          LINESEARCH:     3PNT         # ROBUST: more robust than default (2PNT)
+
+        MIXING:
+          METHOD: DIRECT_P_MIXING
+          ALPHA:  0.4 # = Default: it does not seem to contribute much
+          BETA:   0.5 # = Default: it does not seem to contribute much
+      XC:
+        XC_FUNCTIONAL:
+          PBE:
+            PARAMETRIZATION: ORIG
+        VDW_POTENTIAL:
+           POTENTIAL_TYPE:  PAIR_POTENTIAL
+           PAIR_POTENTIAL:
+              PARAMETER_FILE_NAME:   dftd3.dat
+              TYPE:                  DFTD3(BJ)
+              REFERENCE_FUNCTIONAL:   PBE
+      PRINT:
+        MO_CUBES:
+          WRITE_CUBE: F
+          ADD_LAST: SYMBOLIC
+          EACH:
+            CELL_OPT: 0
+            GEO_OPT: 0
+            MD: 0
+          NHOMO: 1  # all eigenvalues are dumped anyway
+          NLUMO: 1  # specified neigenvalues are dupmed
+        MULLIKEN:
+          _: 'ON'
+          ADD_LAST: SYMBOLIC
+          EACH:
+            CELL_OPT: 0
+            GEO_OPT: 0
+            MD: 0
+        LOWDIN:
+          _: 'OFF'
+        HIRSHFELD:
+          _: 'OFF'
+
+  MOTION:
+    PRINT:
+      TRAJECTORY:
+        FORMAT: DCD_ALIGNED_CELL
+        EACH:
+          CELL_OPT: 1
+          GEO_OPT: 1
+          MD: 1
+      RESTART:
+        BACKUP_COPIES: 0
+        EACH:
+          CELL_OPT: 1
+          GEO_OPT: 1
+          MD: 1
+      RESTART_HISTORY:
+        _: OFF
+      CELL:
+        _: OFF
+      VELOCITIES:
+        _: OFF
+      FORCES:
+        _: OFF
+      STRESS:
+        _: OFF
+
+settings_1: # alternative settings #1, using smearing+diagonalization
+  FORCE_EVAL:
+    DFT:
+      QS:
+        EXTRAPOLATION: USE_PREV_WF  #ASPC not good with smearing
+      SCF:
+        MAX_SCF: 200                # ROBUST: much more
+        ADDED_MOS: 1000
+        SMEAR:
+          _:  ON
+          METHOD: FERMI_DIRAC
+          ELECTRONIC_TEMPERATURE: '[K] 800' # ROBUST: more than standard (300K)
+        DIAGONALIZATION:
+          ALGORITHM: STANDARD
+        OT:
+          _: False
+        OUTER_SCF:
+          _: False
+        MIXING:
+          METHOD: BROYDEN_MIXING
+          ALPHA: 0.2  # ROBUST: less than default (0.4)
+          BETA: 1.5   # ROBUST: more than default (0.5)
+          NBROYDEN: 8 # ROBUST: more than default (4)
+
+# Defining stage's settings (relative to the &MOTION)
+stage_0:
+  GLOBAL:
+    RUN_TYPE: GEO_OPT
+  MOTION:
+    GEO_OPT:
+      TYPE: MINIMIZATION                     #default: MINIMIZATION
+      OPTIMIZER: BFGS                        #default: BFGS
+      MAX_ITER:  5                           #default: 200
+      MAX_DR:    "[bohr] 0.0030"             #default: [bohr] 0.0030
+      RMS_DR:    "[bohr] 0.0015"             #default: [bohr] 0.0015
+      MAX_FORCE: "[bohr^-1*hartree] 0.00045"  #default: [bohr^-1*hartree] 0.00045
+      RMS_FORCE: "[bohr^-1*hartree] 0.00030"  #default: [bohr^-1*hartree] 0.00030
+      BFGS:
+          TRUST_RADIUS: "[angstrom] 0.25"      #default: [angstrom] 0.25
+
+stage_1:
+  GLOBAL:
+    RUN_TYPE: CELL_OPT
+  MOTION:
+    CELL_OPT:
+      TYPE: DIRECT_CELL_OPT                   #default: DIRECT_CELL_OPT
+      EXTERNAL_PRESSURE:  "[bar] 0.0"
+      PRESSURE_TOLERANCE: "[bar] 100"         #default: 100
+      KEEP_ANGLES:   False
+      KEEP_SYMMETRY: False
+      OPTIMIZER: LBFGS                        #default: BFGS
+      MAX_ITER:  1000                         #default: 200
+      MAX_DR:    "[bohr] 0.0030"              #default: [bohr] 0.0030
+      RMS_DR:    "[bohr] 0.0015"              #default: [bohr] 0.0015
+      MAX_FORCE: "[bohr^-1*hartree] 0.00045"  #default: [bohr^-1*hartree] 0.00045
+      RMS_FORCE: "[bohr^-1*hartree] 0.00030"  #default: [bohr^-1*hartree] 0.00030
+      LBFGS:
+        TRUST_RADIUS: "[angstrom] 0.5"

--- a/aiida_lsmo/workchains/cp2k_multistage_protocols/singlepoint.yaml
+++ b/aiida_lsmo/workchains/cp2k_multistage_protocols/singlepoint.yaml
@@ -1,0 +1,339 @@
+protocol_description: >
+  Protocol that performs a single point calculation,
+  with DZVP-MOLOPT-SR basis set with PBE-D3(BJ) functional,
+  using OT as settings_0 and DIAGONALIZATION+SMEAR as settings_1.
+
+# Defining atomic properties
+
+initial_magnetization:
+  H:  0
+  Li: 0  # oxidation state +1
+  Be: 0  # oxidation state +2
+  B:  0
+  C:  0
+  N:  0
+  O:  0
+  F:  0
+  Na: 0  # oxidation state +1
+  Mg: 0  # oxidation state +2
+  Al: 0  # oxidation state +3
+  Si: 0
+  P:  0
+  S:  0
+  Cl: 0
+  K:  0  # oxidation state +1
+  Ca: 0  # oxidation state +2
+  Sc: 0  # oxidation state +1
+  Ti: 0  # oxidation state +4
+  V:  3  # oxidation state +2 high spin
+  Cr: 4  # oxidation state +2 high spin
+  Mn: 5  # oxidation state +2 high spin
+  Fe: 4  # oxidation state +2 high spin
+  Co: 3  # oxidation state +2 high spin
+  Ni: 2  # oxidation state +2 high spin
+  Cu: 1  # oxidation state +2 high spin
+  Zn: 0  # oxidation state +2
+  Zr: 0  # oxidation state +4
+
+basis_set:
+  H:  DZVP-MOLOPT-SR-GTH-q1
+  He: DZVP-MOLOPT-SR-GTH-q2
+  Li: DZVP-MOLOPT-SR-GTH-q3
+  Be: DZVP-MOLOPT-SR-GTH-q4
+  B:  DZVP-MOLOPT-SR-GTH-q3
+  C:  DZVP-MOLOPT-SR-GTH-q4
+  N:  DZVP-MOLOPT-SR-GTH-q5
+  O:  DZVP-MOLOPT-SR-GTH-q6
+  F:  DZVP-MOLOPT-SR-GTH-q7
+  Ne: DZVP-MOLOPT-SR-GTH-q8
+  Na: DZVP-MOLOPT-SR-GTH-q9
+  Mg: DZVP-MOLOPT-SR-GTH-q2
+  Al: DZVP-MOLOPT-SR-GTH-q3
+  Si: DZVP-MOLOPT-SR-GTH-q4
+  P:  DZVP-MOLOPT-SR-GTH-q5
+  S:  DZVP-MOLOPT-SR-GTH-q6
+  Cl: DZVP-MOLOPT-SR-GTH-q7
+  Ar: DZVP-MOLOPT-SR-GTH-q8
+  K:  DZVP-MOLOPT-SR-GTH-q9
+  Ca: DZVP-MOLOPT-SR-GTH-q10
+  Sc: DZVP-MOLOPT-SR-GTH-q11
+  Ti: DZVP-MOLOPT-SR-GTH-q12
+  V:  DZVP-MOLOPT-SR-GTH-q13
+  Cr: DZVP-MOLOPT-SR-GTH-q14
+  Mn: DZVP-MOLOPT-SR-GTH-q15
+  Fe: DZVP-MOLOPT-SR-GTH-q16
+  Co: DZVP-MOLOPT-SR-GTH-q17
+  Ni: DZVP-MOLOPT-SR-GTH-q18
+  Cu: DZVP-MOLOPT-SR-GTH-q11
+  Zn: DZVP-MOLOPT-SR-GTH-q12
+  Ga: DZVP-MOLOPT-SR-GTH-q13
+  Ge: DZVP-MOLOPT-SR-GTH-q4
+  As: DZVP-MOLOPT-SR-GTH-q5
+  Se: DZVP-MOLOPT-SR-GTH-q6
+  Br: DZVP-MOLOPT-SR-GTH-q7
+  Kr: DZVP-MOLOPT-SR-GTH-q8
+  Rb: DZVP-MOLOPT-SR-GTH-q9
+  Sr: DZVP-MOLOPT-SR-GTH-q10
+  Y:  DZVP-MOLOPT-SR-GTH-q11
+  Zr: DZVP-MOLOPT-SR-GTH-q12
+  Nb: DZVP-MOLOPT-SR-GTH-q13
+  Mo: DZVP-MOLOPT-SR-GTH-q14
+  Tc: DZVP-MOLOPT-SR-GTH-q15
+  Ru: DZVP-MOLOPT-SR-GTH-q16
+  Rh: DZVP-MOLOPT-SR-GTH-q9
+  Pd: DZVP-MOLOPT-SR-GTH-q18
+  Ag: DZVP-MOLOPT-SR-GTH-q11
+  Cd: DZVP-MOLOPT-SR-GTH-q12
+  In: DZVP-MOLOPT-SR-GTH-q13
+  Sn: DZVP-MOLOPT-SR-GTH-q4
+  Sb: DZVP-MOLOPT-SR-GTH-q5
+  Te: DZVP-MOLOPT-SR-GTH-q6
+  I:  DZVP-MOLOPT-SR-GTH-q7
+  Xe: DZVP-MOLOPT-SR-GTH-q8
+  Cs: DZVP-MOLOPT-SR-GTH-q9
+  Ba: DZVP-MOLOPT-SR-GTH-q10
+  La: DZVP-MOLOPT-SR-GTH-q11
+  Ce: DZVP-MOLOPT-SR-GTH-q12
+  Pr: DZVP-MOLOPT-SR-GTH-q13
+  Nd: DZVP-MOLOPT-SR-GTH-q14
+  Pm: DZVP-MOLOPT-SR-GTH-q15
+  Sm: DZVP-MOLOPT-SR-GTH-q16
+  Eu: DZVP-MOLOPT-SR-GTH-q17
+  Gd: DZVP-MOLOPT-SR-GTH-q18
+  Tb: DZVP-MOLOPT-SR-GTH-q19
+  Dy: DZVP-MOLOPT-SR-GTH-q20
+  Ho: DZVP-MOLOPT-SR-GTH-q21
+  Er: DZVP-MOLOPT-SR-GTH-q22
+  Tm: DZVP-MOLOPT-SR-GTH-q23
+  Yb: DZVP-MOLOPT-SR-GTH-q24
+  Lu: DZVP-MOLOPT-SR-GTH-q25
+  Hf: DZVP-MOLOPT-SR-GTH-q12
+  Ta: DZVP-MOLOPT-SR-GTH-q13
+  W:  DZVP-MOLOPT-SR-GTH-q14
+  Re: DZVP-MOLOPT-SR-GTH-q15
+  Os: DZVP-MOLOPT-SR-GTH-q16
+  Ir: DZVP-MOLOPT-SR-GTH-q17
+  Pt: DZVP-MOLOPT-SR-GTH-q18
+  Au: DZVP-MOLOPT-SR-GTH-q11
+  Hg: DZVP-MOLOPT-SR-GTH-q12
+  Tl: DZVP-MOLOPT-SR-GTH-q13
+  Pb: DZVP-MOLOPT-SR-GTH-q4
+  Bi: DZVP-MOLOPT-SR-GTH-q5
+  Po: DZVP-MOLOPT-SR-GTH-q6
+  At: DZVP-MOLOPT-SR-GTH-q7
+  Rn: DZVP-MOLOPT-SR-GTH-q8
+
+pseudopotential:
+   H:  GTH-PBE-q1
+   He: GTH-PBE-q2
+   Li: GTH-PBE-q3
+   Be: GTH-PBE-q4
+   B:  GTH-PBE-q3
+   C:  GTH-PBE-q4
+   N:  GTH-PBE-q5
+   O:  GTH-PBE-q6
+   F:  GTH-PBE-q7
+   Ne: GTH-PBE-q8
+   Na: GTH-PBE-q9
+   Mg: GTH-PBE-q2
+   Al: GTH-PBE-q3
+   Si: GTH-PBE-q4
+   P:  GTH-PBE-q5
+   S:  GTH-PBE-q6
+   Cl: GTH-PBE-q7
+   Ar: GTH-PBE-q8
+   K:  GTH-PBE-q9
+   Ca: GTH-PBE-q10
+   Sc: GTH-PBE-q11
+   Ti: GTH-PBE-q12
+   V:  GTH-PBE-q13
+   Cr: GTH-PBE-q14
+   Mn: GTH-PBE-q15
+   Fe: GTH-PBE-q16
+   Co: GTH-PBE-q17
+   Ni: GTH-PBE-q18
+   Cu: GTH-PBE-q11
+   Zn: GTH-PBE-q12
+   Ga: GTH-PBE-q13
+   Ge: GTH-PBE-q4
+   As: GTH-PBE-q5
+   Se: GTH-PBE-q6
+   Br: GTH-PBE-q7
+   Kr: GTH-PBE-q8
+   Rb: GTH-PBE-q9
+   Sr: GTH-PBE-q10
+   Y:  GTH-PBE-q11
+   Zr: GTH-PBE-q12
+   Nb: GTH-PBE-q13
+   Mo: GTH-PBE-q14
+   Tc: GTH-PBE-q15
+   Ru: GTH-PBE-q16
+   Rh: GTH-PBE-q9
+   Pd: GTH-PBE-q18
+   Ag: GTH-PBE-q11
+   Cd: GTH-PBE-q12
+   In: GTH-PBE-q13
+   Sn: GTH-PBE-q4
+   Sb: GTH-PBE-q5
+   Te: GTH-PBE-q6
+   I:  GTH-PBE-q7
+   Xe: GTH-PBE-q8
+   Cs: GTH-PBE-q9
+   Ba: GTH-PBE-q10
+   La: GTH-PBE-q11
+   Ce: GTH-PBE-q12
+   Pr: GTH-PBE-q13
+   Nd: GTH-PBE-q14
+   Pm: GTH-PBE-q15
+   Sm: GTH-PBE-q16
+   Eu: GTH-PBE-q17
+   Gd: GTH-PBE-q18
+   Tb: GTH-PBE-q19
+   Dy: GTH-PBE-q20
+   Ho: GTH-PBE-q21
+   Er: GTH-PBE-q22
+   Tm: GTH-PBE-q23
+   Yb: GTH-PBE-q24
+   Lu: GTH-PBE-q25
+   Hf: GTH-PBE-q12
+   Ta: GTH-PBE-q13
+   W:  GTH-PBE-q14
+   Re: GTH-PBE-q15
+   Os: GTH-PBE-q16
+   Ir: GTH-PBE-q17
+   Pt: GTH-PBE-q18
+   Au: GTH-PBE-q11
+   Hg: GTH-PBE-q12
+   Tl: GTH-PBE-q13
+   Pb: GTH-PBE-q4
+   Bi: GTH-PBE-q5
+   Po: GTH-PBE-q6
+   At: GTH-PBE-q7
+   Rn: GTH-PBE-q8
+
+# Defining input settings
+bandgap_thr_ev: 0.1 #bandgap threshold minimum under which the OT is not considered as valid
+
+settings_0: # main settings exploiting OT
+  GLOBAL:
+    PRINT_LEVEL: MEDIUM              #default: MEDIUM. Important to have the correct parsing
+  FORCE_EVAL:
+    METHOD:         QUICKSTEP
+    STRESS_TENSOR:  ANALYTICAL
+    DFT:
+      BASIS_SET_FILE_NAME:
+        - BASIS_MOLOPT
+        - BASIS_MOLOPT_UCL
+      POTENTIAL_FILE_NAME:
+        -  GTH_POTENTIALS
+      UKS:          False
+      CHARGE:       0
+      MULTIPLICITY: 0
+      MGRID:
+        CUTOFF:      600
+        REL_CUTOFF:  50
+        NGRIDS:      4
+      QS:
+        METHOD: GPW
+        EPS_DEFAULT:   1.0E-10
+        EXTRAPOLATION: ASPC
+
+      SCF:
+        MAX_SCF:       50
+        EPS_SCF:       1.0E-7
+        MAX_ITER_LUMO: 10000         # for computing the Band gap
+        OUTER_SCF:
+          MAX_SCF:   10              # not too many: it has 5 GEO_OPT to converge initially
+          EPS_SCF:   1.0E-7          # equal (or smaller for expert use) than SCF/EPS_SCF
+        OT:
+          PRECONDITIONER: FULL_ALL
+          MINIMIZER:      DIIS
+
+        MIXING:
+          METHOD: DIRECT_P_MIXING
+          ALPHA:  0.4
+          BETA:   0.5
+      XC:
+        XC_FUNCTIONAL:
+          PBE:
+            PARAMETRIZATION: ORIG
+        VDW_POTENTIAL:
+           POTENTIAL_TYPE:  PAIR_POTENTIAL
+           PAIR_POTENTIAL:
+              PARAMETER_FILE_NAME:   dftd3.dat
+              TYPE:                  DFTD3(BJ)
+              REFERENCE_FUNCTIONAL:   PBE
+      PRINT:
+        MO_CUBES:
+          WRITE_CUBE: F
+          ADD_LAST: SYMBOLIC
+          EACH:
+            CELL_OPT: 0
+            GEO_OPT: 0
+            MD: 0
+          NHOMO: 1  # all eigenvalues are dumped anyway
+          NLUMO: 1  # specified neigenvalues are dupmed
+        MULLIKEN:
+          _: 'ON'
+          ADD_LAST: SYMBOLIC
+          EACH:
+            CELL_OPT: 0
+            GEO_OPT: 0
+            MD: 0
+        LOWDIN:
+          _: 'OFF'
+        HIRSHFELD:
+          _: 'OFF'
+
+  MOTION:
+    PRINT:
+      TRAJECTORY:
+        FORMAT: DCD_ALIGNED_CELL
+        EACH:
+          CELL_OPT: 1
+          GEO_OPT: 1
+          MD: 1
+      RESTART:
+        BACKUP_COPIES: 0
+        EACH:
+          CELL_OPT: 1
+          GEO_OPT: 1
+          MD: 1
+      RESTART_HISTORY:
+        _: OFF
+      CELL:
+        _: OFF
+      VELOCITIES:
+        _: OFF
+      FORCES:
+        _: OFF
+      STRESS:
+        _: OFF
+
+settings_1: # alternative settings #1, using smearing+diagonalization
+  FORCE_EVAL:
+    DFT:
+      QS:
+        EXTRAPOLATION: USE_PREV_WF  #ASPC not good wioth smearing
+      SCF:
+        MAX_SCF: 400                # not too many: it has 5 GEO_OPT to converge initially
+        ADDED_MOS: 1000
+        SMEAR:
+          _:  ON
+          METHOD: FERMI_DIRAC
+          ELECTRONIC_TEMPERATURE: '[K] 300'
+        DIAGONALIZATION:
+          ALGORITHM: STANDARD
+        OT:
+          _: False
+        OUTER_SCF:
+          _: False
+        MIXING:
+          METHOD: BROYDEN_MIXING
+          ALPHA: 0.4
+          NBROYDEN: 8
+
+# Defining stage's settings (relative to the &MOTION)
+stage_0:
+  GLOBAL:
+    RUN_TYPE: ENERGY

--- a/aiida_lsmo/workchains/cp2k_multistage_protocols/standard.yaml
+++ b/aiida_lsmo/workchains/cp2k_multistage_protocols/standard.yaml
@@ -1,0 +1,388 @@
+protocol_description: >
+  Protocol that performs a "standard" calculation, defined as:
+  DZVP-MOLOPT-SR basis set (600Ry CUTOFF) with PBE-D3(BJ) functional,
+  high spin initial magnetization at the common oxidation state,
+  using OT as settings_0 and DIAGONALIZATION+SMEAR as settings_1,
+  running a short 5-steps GEO_OPT, then a 100*0.5fs NPT-MD, and a final CELL_OPT.
+
+# Defining atomic properties
+
+initial_magnetization:
+  H:  0
+  Li: 0  # oxidation state +1
+  Be: 0  # oxidation state +2
+  B:  0
+  C:  0
+  N:  0
+  O:  0
+  F:  0
+  Na: 0  # oxidation state +1
+  Mg: 0  # oxidation state +2
+  Al: 0  # oxidation state +3
+  Si: 0
+  P:  0
+  S:  0
+  Cl: 0
+  K:  0  # oxidation state +1
+  Ca: 0  # oxidation state +2
+  Sc: 0  # oxidation state +1
+  Ti: 0  # oxidation state +4
+  V:  3  # oxidation state +2 high spin
+  Cr: 4  # oxidation state +2 high spin
+  Mn: 5  # oxidation state +2 high spin
+  Fe: 4  # oxidation state +2 high spin
+  Co: 3  # oxidation state +2 high spin
+  Ni: 2  # oxidation state +2 high spin
+  Cu: 1  # oxidation state +2 high spin
+  Zn: 0  # oxidation state +2
+  Zr: 0  # oxidation state +4
+
+basis_set:
+  H:  DZVP-MOLOPT-SR-GTH-q1
+  He: DZVP-MOLOPT-SR-GTH-q2
+  Li: DZVP-MOLOPT-SR-GTH-q3
+  Be: DZVP-MOLOPT-SR-GTH-q4
+  B:  DZVP-MOLOPT-SR-GTH-q3
+  C:  DZVP-MOLOPT-SR-GTH-q4
+  N:  DZVP-MOLOPT-SR-GTH-q5
+  O:  DZVP-MOLOPT-SR-GTH-q6
+  F:  DZVP-MOLOPT-SR-GTH-q7
+  Ne: DZVP-MOLOPT-SR-GTH-q8
+  Na: DZVP-MOLOPT-SR-GTH-q9
+  Mg: DZVP-MOLOPT-SR-GTH-q2
+  Al: DZVP-MOLOPT-SR-GTH-q3
+  Si: DZVP-MOLOPT-SR-GTH-q4
+  P:  DZVP-MOLOPT-SR-GTH-q5
+  S:  DZVP-MOLOPT-SR-GTH-q6
+  Cl: DZVP-MOLOPT-SR-GTH-q7
+  Ar: DZVP-MOLOPT-SR-GTH-q8
+  K:  DZVP-MOLOPT-SR-GTH-q9
+  Ca: DZVP-MOLOPT-SR-GTH-q10
+  Sc: DZVP-MOLOPT-SR-GTH-q11
+  Ti: DZVP-MOLOPT-SR-GTH-q12
+  V:  DZVP-MOLOPT-SR-GTH-q13
+  Cr: DZVP-MOLOPT-SR-GTH-q14
+  Mn: DZVP-MOLOPT-SR-GTH-q15
+  Fe: DZVP-MOLOPT-SR-GTH-q16
+  Co: DZVP-MOLOPT-SR-GTH-q17
+  Ni: DZVP-MOLOPT-SR-GTH-q18
+  Cu: DZVP-MOLOPT-SR-GTH-q11
+  Zn: DZVP-MOLOPT-SR-GTH-q12
+  Ga: DZVP-MOLOPT-SR-GTH-q13
+  Ge: DZVP-MOLOPT-SR-GTH-q4
+  As: DZVP-MOLOPT-SR-GTH-q5
+  Se: DZVP-MOLOPT-SR-GTH-q6
+  Br: DZVP-MOLOPT-SR-GTH-q7
+  Kr: DZVP-MOLOPT-SR-GTH-q8
+  Rb: DZVP-MOLOPT-SR-GTH-q9
+  Sr: DZVP-MOLOPT-SR-GTH-q10
+  Y:  DZVP-MOLOPT-SR-GTH-q11
+  Zr: DZVP-MOLOPT-SR-GTH-q12
+  Nb: DZVP-MOLOPT-SR-GTH-q13
+  Mo: DZVP-MOLOPT-SR-GTH-q14
+  Tc: DZVP-MOLOPT-SR-GTH-q15
+  Ru: DZVP-MOLOPT-SR-GTH-q16
+  Rh: DZVP-MOLOPT-SR-GTH-q9
+  Pd: DZVP-MOLOPT-SR-GTH-q18
+  Ag: DZVP-MOLOPT-SR-GTH-q11
+  Cd: DZVP-MOLOPT-SR-GTH-q12
+  In: DZVP-MOLOPT-SR-GTH-q13
+  Sn: DZVP-MOLOPT-SR-GTH-q4
+  Sb: DZVP-MOLOPT-SR-GTH-q5
+  Te: DZVP-MOLOPT-SR-GTH-q6
+  I:  DZVP-MOLOPT-SR-GTH-q7
+  Xe: DZVP-MOLOPT-SR-GTH-q8
+  Cs: DZVP-MOLOPT-SR-GTH-q9
+  Ba: DZVP-MOLOPT-SR-GTH-q10
+  La: DZVP-MOLOPT-SR-GTH-q11
+  Ce: DZVP-MOLOPT-SR-GTH-q12
+  Pr: DZVP-MOLOPT-SR-GTH-q13
+  Nd: DZVP-MOLOPT-SR-GTH-q14
+  Pm: DZVP-MOLOPT-SR-GTH-q15
+  Sm: DZVP-MOLOPT-SR-GTH-q16
+  Eu: DZVP-MOLOPT-SR-GTH-q17
+  Gd: DZVP-MOLOPT-SR-GTH-q18
+  Tb: DZVP-MOLOPT-SR-GTH-q19
+  Dy: DZVP-MOLOPT-SR-GTH-q20
+  Ho: DZVP-MOLOPT-SR-GTH-q21
+  Er: DZVP-MOLOPT-SR-GTH-q22
+  Tm: DZVP-MOLOPT-SR-GTH-q23
+  Yb: DZVP-MOLOPT-SR-GTH-q24
+  Lu: DZVP-MOLOPT-SR-GTH-q25
+  Hf: DZVP-MOLOPT-SR-GTH-q12
+  Ta: DZVP-MOLOPT-SR-GTH-q13
+  W:  DZVP-MOLOPT-SR-GTH-q14
+  Re: DZVP-MOLOPT-SR-GTH-q15
+  Os: DZVP-MOLOPT-SR-GTH-q16
+  Ir: DZVP-MOLOPT-SR-GTH-q17
+  Pt: DZVP-MOLOPT-SR-GTH-q18
+  Au: DZVP-MOLOPT-SR-GTH-q11
+  Hg: DZVP-MOLOPT-SR-GTH-q12
+  Tl: DZVP-MOLOPT-SR-GTH-q13
+  Pb: DZVP-MOLOPT-SR-GTH-q4
+  Bi: DZVP-MOLOPT-SR-GTH-q5
+  Po: DZVP-MOLOPT-SR-GTH-q6
+  At: DZVP-MOLOPT-SR-GTH-q7
+  Rn: DZVP-MOLOPT-SR-GTH-q8
+
+pseudopotential:
+   H:  GTH-PBE-q1
+   He: GTH-PBE-q2
+   Li: GTH-PBE-q3
+   Be: GTH-PBE-q4
+   B:  GTH-PBE-q3
+   C:  GTH-PBE-q4
+   N:  GTH-PBE-q5
+   O:  GTH-PBE-q6
+   F:  GTH-PBE-q7
+   Ne: GTH-PBE-q8
+   Na: GTH-PBE-q9
+   Mg: GTH-PBE-q2
+   Al: GTH-PBE-q3
+   Si: GTH-PBE-q4
+   P:  GTH-PBE-q5
+   S:  GTH-PBE-q6
+   Cl: GTH-PBE-q7
+   Ar: GTH-PBE-q8
+   K:  GTH-PBE-q9
+   Ca: GTH-PBE-q10
+   Sc: GTH-PBE-q11
+   Ti: GTH-PBE-q12
+   V:  GTH-PBE-q13
+   Cr: GTH-PBE-q14
+   Mn: GTH-PBE-q15
+   Fe: GTH-PBE-q16
+   Co: GTH-PBE-q17
+   Ni: GTH-PBE-q18
+   Cu: GTH-PBE-q11
+   Zn: GTH-PBE-q12
+   Ga: GTH-PBE-q13
+   Ge: GTH-PBE-q4
+   As: GTH-PBE-q5
+   Se: GTH-PBE-q6
+   Br: GTH-PBE-q7
+   Kr: GTH-PBE-q8
+   Rb: GTH-PBE-q9
+   Sr: GTH-PBE-q10
+   Y:  GTH-PBE-q11
+   Zr: GTH-PBE-q12
+   Nb: GTH-PBE-q13
+   Mo: GTH-PBE-q14
+   Tc: GTH-PBE-q15
+   Ru: GTH-PBE-q16
+   Rh: GTH-PBE-q9
+   Pd: GTH-PBE-q18
+   Ag: GTH-PBE-q11
+   Cd: GTH-PBE-q12
+   In: GTH-PBE-q13
+   Sn: GTH-PBE-q4
+   Sb: GTH-PBE-q5
+   Te: GTH-PBE-q6
+   I:  GTH-PBE-q7
+   Xe: GTH-PBE-q8
+   Cs: GTH-PBE-q9
+   Ba: GTH-PBE-q10
+   La: GTH-PBE-q11
+   Ce: GTH-PBE-q12
+   Pr: GTH-PBE-q13
+   Nd: GTH-PBE-q14
+   Pm: GTH-PBE-q15
+   Sm: GTH-PBE-q16
+   Eu: GTH-PBE-q17
+   Gd: GTH-PBE-q18
+   Tb: GTH-PBE-q19
+   Dy: GTH-PBE-q20
+   Ho: GTH-PBE-q21
+   Er: GTH-PBE-q22
+   Tm: GTH-PBE-q23
+   Yb: GTH-PBE-q24
+   Lu: GTH-PBE-q25
+   Hf: GTH-PBE-q12
+   Ta: GTH-PBE-q13
+   W:  GTH-PBE-q14
+   Re: GTH-PBE-q15
+   Os: GTH-PBE-q16
+   Ir: GTH-PBE-q17
+   Pt: GTH-PBE-q18
+   Au: GTH-PBE-q11
+   Hg: GTH-PBE-q12
+   Tl: GTH-PBE-q13
+   Pb: GTH-PBE-q4
+   Bi: GTH-PBE-q5
+   Po: GTH-PBE-q6
+   At: GTH-PBE-q7
+   Rn: GTH-PBE-q8
+
+# Defining input settings
+bandgap_thr_ev: 0.1 #bandgap threshold minimum under which the OT is not considered as valid
+
+settings_0: # main settings exploiting OT
+  GLOBAL:
+    PRINT_LEVEL: MEDIUM              #default: MEDIUM. Important to have the correct parsing
+  FORCE_EVAL:
+    METHOD:         QUICKSTEP
+    STRESS_TENSOR:  ANALYTICAL
+    DFT:
+      BASIS_SET_FILE_NAME:
+        - BASIS_MOLOPT
+        - BASIS_MOLOPT_UCL
+      POTENTIAL_FILE_NAME:
+        -  GTH_POTENTIALS
+      UKS:          False
+      CHARGE:       0
+      MULTIPLICITY: 0
+      MGRID:
+        CUTOFF:      600
+        REL_CUTOFF:  50
+        NGRIDS:      4
+      QS:
+        METHOD: GPW
+        EPS_DEFAULT:   1.0E-10
+        EXTRAPOLATION: ASPC
+
+      SCF:
+        MAX_SCF:       50
+        EPS_SCF:       1.0E-7
+        MAX_ITER_LUMO: 10000         # for computing the Band gap
+        OUTER_SCF:
+          MAX_SCF:   4               # not too many: it has 5 GEO_OPT to converge initially
+          EPS_SCF:   1.0E-7          # equal (or smaller for expert use) than SCF/EPS_SCF
+        OT:
+          PRECONDITIONER: FULL_ALL
+          MINIMIZER:      DIIS
+
+        MIXING:
+          METHOD: DIRECT_P_MIXING
+          ALPHA:  0.4
+          BETA:   0.5
+      XC:
+        XC_FUNCTIONAL:
+          PBE:
+            PARAMETRIZATION: ORIG
+        VDW_POTENTIAL:
+           POTENTIAL_TYPE:  PAIR_POTENTIAL
+           PAIR_POTENTIAL:
+              PARAMETER_FILE_NAME:   dftd3.dat
+              TYPE:                  DFTD3(BJ)
+              REFERENCE_FUNCTIONAL:   PBE
+      PRINT:
+        MO_CUBES:
+          WRITE_CUBE: F
+          ADD_LAST: SYMBOLIC
+          EACH:
+            CELL_OPT: 0
+            GEO_OPT: 0
+            MD: 0
+          NHOMO: 1  # all eigenvalues are dumped anyway
+          NLUMO: 1  # specified neigenvalues are dupmed
+        MULLIKEN:
+          _: 'ON'
+          ADD_LAST: SYMBOLIC
+          EACH:
+            CELL_OPT: 0
+            GEO_OPT: 0
+            MD: 0
+        LOWDIN:
+          _: 'OFF'
+        HIRSHFELD:
+          _: 'OFF'
+
+  MOTION:
+    PRINT:
+      TRAJECTORY:
+        FORMAT: DCD_ALIGNED_CELL
+        EACH:
+          CELL_OPT: 1
+          GEO_OPT: 1
+          MD: 1
+      RESTART:
+        BACKUP_COPIES: 0
+        EACH:
+          CELL_OPT: 1
+          GEO_OPT: 1
+          MD: 1
+      RESTART_HISTORY:
+        _: OFF
+      CELL:
+        _: OFF
+      VELOCITIES:
+        _: OFF
+      FORCES:
+        _: OFF
+      STRESS:
+        _: OFF
+
+settings_1: # alternative settings #1, using smearing+diagonalization
+  FORCE_EVAL:
+    DFT:
+      QS:
+        EXTRAPOLATION: USE_PREV_WF  #ASPC not good wioth smearing
+      SCF:
+        MAX_SCF: 400                # not too many: it has 5 GEO_OPT to converge initially
+        ADDED_MOS: 1000
+        SMEAR:
+          _:  ON
+          METHOD: FERMI_DIRAC
+          ELECTRONIC_TEMPERATURE: '[K] 300'
+        DIAGONALIZATION:
+          ALGORITHM: STANDARD
+        OT:
+          _: False
+        OUTER_SCF:
+          _: False
+        MIXING:
+          METHOD: BROYDEN_MIXING
+          ALPHA: 0.4
+          NBROYDEN: 8
+
+# Defining stage's settings (relative to the &MOTION)
+stage_0:
+  GLOBAL:
+    RUN_TYPE: GEO_OPT
+  MOTION:
+    GEO_OPT:
+      TYPE: MINIMIZATION                     #default: MINIMIZATION
+      OPTIMIZER: BFGS                        #default: BFGS
+      MAX_ITER:  5                           #default: 200
+      MAX_DR:    "[bohr] 0.0030"             #default: [bohr] 0.0030
+      RMS_DR:    "[bohr] 0.0015"             #default: [bohr] 0.0015
+      MAX_FORCE: "[bohr^-1*hartree] 0.00045"  #default: [bohr^-1*hartree] 0.00045
+      RMS_FORCE: "[bohr^-1*hartree] 0.00030"  #default: [bohr^-1*hartree] 0.00030
+      BFGS:
+          TRUST_RADIUS: "[angstrom] 0.25"      #default: [angstrom] 0.25
+
+stage_1:
+  GLOBAL:
+    RUN_TYPE: MD
+  MOTION:
+    MD:
+      ENSEMBLE:        NPT_F
+      STEPS:           100
+      TIMESTEP: "[fs]  0.5"
+      TEMPERATURE:     300
+      THERMOSTAT:
+        TYPE: CSVR
+        CSVR:
+          TIMECON: "[fs] 0.1"   ### SLing: 0.1 small time constant (strong coupling) for equilibration; change to 50~100 or bigger for production run
+      BAROSTAT:                 #by default the barosthat uses the same thermo as the partricles
+        PRESSURE: "[bar] 0.0"  #default: 0.0
+        TIMECON:  "[fs] 500"   #default: 1000, good for crystals
+
+stage_2:
+  GLOBAL:
+    RUN_TYPE: CELL_OPT
+  MOTION:
+    CELL_OPT:
+      TYPE: DIRECT_CELL_OPT                   #default: DIRECT_CELL_OPT
+      EXTERNAL_PRESSURE:  "[bar] 0.0"
+      PRESSURE_TOLERANCE: "[bar] 100"         #default: 100
+      KEEP_ANGLES:   False
+      KEEP_SYMMETRY: False
+      OPTIMIZER: LBFGS                        #default: BFGS
+      MAX_ITER:  1000                         #default: 200
+      MAX_DR:    "[bohr] 0.0030"              #default: [bohr] 0.0030
+      RMS_DR:    "[bohr] 0.0015"              #default: [bohr] 0.0015
+      MAX_FORCE: "[bohr^-1*hartree] 0.00045"  #default: [bohr^-1*hartree] 0.00045
+      RMS_FORCE: "[bohr^-1*hartree] 0.00030"  #default: [bohr^-1*hartree] 0.00030
+      LBFGS:
+        TRUST_RADIUS: "[angstrom] 0.5"

--- a/aiida_lsmo/workchains/cp2k_multistage_protocols/test.yaml
+++ b/aiida_lsmo/workchains/cp2k_multistage_protocols/test.yaml
@@ -1,0 +1,365 @@
+protocol_description: >
+  Protocol that performs a quick calculation for testing purpose,
+  with DZVP-MOLOPT-SR basis set with PBE-D3(BJ) functional,
+  an a limited CUTOFF of 300Ry (30Ry, REL_CUTOFF),
+  using OT as settings_0 and DIAGONALIZATION+SMEAR as settings_1.
+  It performs only 2 steps of GEO_OPT and 2 steps of MD.
+
+# Defining atomic properties
+initial_magnetization:
+  H:  0
+  Li: 0  # oxidation state +1
+  Be: 0  # oxidation state +2
+  B:  0
+  C:  0
+  N:  0
+  O:  0
+  F:  0
+  Na: 0  # oxidation state +1
+  Mg: 0  # oxidation state +2
+  Al: 0  # oxidation state +3
+  Si: 0
+  P:  0
+  S:  0
+  Cl: 0
+  K:  0  # oxidation state +1
+  Ca: 0  # oxidation state +2
+  Sc: 0  # oxidation state +1
+  Ti: 0  # oxidation state +4
+  V:  3  # oxidation state +2 high spin
+  Cr: 4  # oxidation state +2 high spin
+  Mn: 5  # oxidation state +2 high spin
+  Fe: 4  # oxidation state +2 high spin
+  Co: 3  # oxidation state +2 high spin
+  Ni: 2  # oxidation state +2 high spin
+  Cu: 1  # oxidation state +2 high spin
+  Zn: 0  # oxidation state +2
+  Zr: 0  # oxidation state +4
+
+basis_set:
+  H:  DZVP-MOLOPT-SR-GTH-q1
+  He: DZVP-MOLOPT-SR-GTH-q2
+  Li: DZVP-MOLOPT-SR-GTH-q3
+  Be: DZVP-MOLOPT-SR-GTH-q4
+  B:  DZVP-MOLOPT-SR-GTH-q3
+  C:  DZVP-MOLOPT-SR-GTH-q4
+  N:  DZVP-MOLOPT-SR-GTH-q5
+  O:  DZVP-MOLOPT-SR-GTH-q6
+  F:  DZVP-MOLOPT-SR-GTH-q7
+  Ne: DZVP-MOLOPT-SR-GTH-q8
+  Na: DZVP-MOLOPT-SR-GTH-q9
+  Mg: DZVP-MOLOPT-SR-GTH-q2
+  Al: DZVP-MOLOPT-SR-GTH-q3
+  Si: DZVP-MOLOPT-SR-GTH-q4
+  P:  DZVP-MOLOPT-SR-GTH-q5
+  S:  DZVP-MOLOPT-SR-GTH-q6
+  Cl: DZVP-MOLOPT-SR-GTH-q7
+  Ar: DZVP-MOLOPT-SR-GTH-q8
+  K:  DZVP-MOLOPT-SR-GTH-q9
+  Ca: DZVP-MOLOPT-SR-GTH-q10
+  Sc: DZVP-MOLOPT-SR-GTH-q11
+  Ti: DZVP-MOLOPT-SR-GTH-q12
+  V:  DZVP-MOLOPT-SR-GTH-q13
+  Cr: DZVP-MOLOPT-SR-GTH-q14
+  Mn: DZVP-MOLOPT-SR-GTH-q15
+  Fe: DZVP-MOLOPT-SR-GTH-q16
+  Co: DZVP-MOLOPT-SR-GTH-q17
+  Ni: DZVP-MOLOPT-SR-GTH-q18
+  Cu: DZVP-MOLOPT-SR-GTH-q11
+  Zn: DZVP-MOLOPT-SR-GTH-q12
+  Ga: DZVP-MOLOPT-SR-GTH-q13
+  Ge: DZVP-MOLOPT-SR-GTH-q4
+  As: DZVP-MOLOPT-SR-GTH-q5
+  Se: DZVP-MOLOPT-SR-GTH-q6
+  Br: DZVP-MOLOPT-SR-GTH-q7
+  Kr: DZVP-MOLOPT-SR-GTH-q8
+  Rb: DZVP-MOLOPT-SR-GTH-q9
+  Sr: DZVP-MOLOPT-SR-GTH-q10
+  Y:  DZVP-MOLOPT-SR-GTH-q11
+  Zr: DZVP-MOLOPT-SR-GTH-q12
+  Nb: DZVP-MOLOPT-SR-GTH-q13
+  Mo: DZVP-MOLOPT-SR-GTH-q14
+  Tc: DZVP-MOLOPT-SR-GTH-q15
+  Ru: DZVP-MOLOPT-SR-GTH-q16
+  Rh: DZVP-MOLOPT-SR-GTH-q9
+  Pd: DZVP-MOLOPT-SR-GTH-q18
+  Ag: DZVP-MOLOPT-SR-GTH-q11
+  Cd: DZVP-MOLOPT-SR-GTH-q12
+  In: DZVP-MOLOPT-SR-GTH-q13
+  Sn: DZVP-MOLOPT-SR-GTH-q4
+  Sb: DZVP-MOLOPT-SR-GTH-q5
+  Te: DZVP-MOLOPT-SR-GTH-q6
+  I:  DZVP-MOLOPT-SR-GTH-q7
+  Xe: DZVP-MOLOPT-SR-GTH-q8
+  Cs: DZVP-MOLOPT-SR-GTH-q9
+  Ba: DZVP-MOLOPT-SR-GTH-q10
+  La: DZVP-MOLOPT-SR-GTH-q11
+  Ce: DZVP-MOLOPT-SR-GTH-q12
+  Pr: DZVP-MOLOPT-SR-GTH-q13
+  Nd: DZVP-MOLOPT-SR-GTH-q14
+  Pm: DZVP-MOLOPT-SR-GTH-q15
+  Sm: DZVP-MOLOPT-SR-GTH-q16
+  Eu: DZVP-MOLOPT-SR-GTH-q17
+  Gd: DZVP-MOLOPT-SR-GTH-q18
+  Tb: DZVP-MOLOPT-SR-GTH-q19
+  Dy: DZVP-MOLOPT-SR-GTH-q20
+  Ho: DZVP-MOLOPT-SR-GTH-q21
+  Er: DZVP-MOLOPT-SR-GTH-q22
+  Tm: DZVP-MOLOPT-SR-GTH-q23
+  Yb: DZVP-MOLOPT-SR-GTH-q24
+  Lu: DZVP-MOLOPT-SR-GTH-q25
+  Hf: DZVP-MOLOPT-SR-GTH-q12
+  Ta: DZVP-MOLOPT-SR-GTH-q13
+  W:  DZVP-MOLOPT-SR-GTH-q14
+  Re: DZVP-MOLOPT-SR-GTH-q15
+  Os: DZVP-MOLOPT-SR-GTH-q16
+  Ir: DZVP-MOLOPT-SR-GTH-q17
+  Pt: DZVP-MOLOPT-SR-GTH-q18
+  Au: DZVP-MOLOPT-SR-GTH-q11
+  Hg: DZVP-MOLOPT-SR-GTH-q12
+  Tl: DZVP-MOLOPT-SR-GTH-q13
+  Pb: DZVP-MOLOPT-SR-GTH-q4
+  Bi: DZVP-MOLOPT-SR-GTH-q5
+  Po: DZVP-MOLOPT-SR-GTH-q6
+  At: DZVP-MOLOPT-SR-GTH-q7
+  Rn: DZVP-MOLOPT-SR-GTH-q8
+
+pseudopotential:
+   H:  GTH-PBE-q1
+   He: GTH-PBE-q2
+   Li: GTH-PBE-q3
+   Be: GTH-PBE-q4
+   B:  GTH-PBE-q3
+   C:  GTH-PBE-q4
+   N:  GTH-PBE-q5
+   O:  GTH-PBE-q6
+   F:  GTH-PBE-q7
+   Ne: GTH-PBE-q8
+   Na: GTH-PBE-q9
+   Mg: GTH-PBE-q2
+   Al: GTH-PBE-q3
+   Si: GTH-PBE-q4
+   P:  GTH-PBE-q5
+   S:  GTH-PBE-q6
+   Cl: GTH-PBE-q7
+   Ar: GTH-PBE-q8
+   K:  GTH-PBE-q9
+   Ca: GTH-PBE-q10
+   Sc: GTH-PBE-q11
+   Ti: GTH-PBE-q12
+   V:  GTH-PBE-q13
+   Cr: GTH-PBE-q14
+   Mn: GTH-PBE-q15
+   Fe: GTH-PBE-q16
+   Co: GTH-PBE-q17
+   Ni: GTH-PBE-q18
+   Cu: GTH-PBE-q11
+   Zn: GTH-PBE-q12
+   Ga: GTH-PBE-q13
+   Ge: GTH-PBE-q4
+   As: GTH-PBE-q5
+   Se: GTH-PBE-q6
+   Br: GTH-PBE-q7
+   Kr: GTH-PBE-q8
+   Rb: GTH-PBE-q9
+   Sr: GTH-PBE-q10
+   Y:  GTH-PBE-q11
+   Zr: GTH-PBE-q12
+   Nb: GTH-PBE-q13
+   Mo: GTH-PBE-q14
+   Tc: GTH-PBE-q15
+   Ru: GTH-PBE-q16
+   Rh: GTH-PBE-q9
+   Pd: GTH-PBE-q18
+   Ag: GTH-PBE-q11
+   Cd: GTH-PBE-q12
+   In: GTH-PBE-q13
+   Sn: GTH-PBE-q4
+   Sb: GTH-PBE-q5
+   Te: GTH-PBE-q6
+   I:  GTH-PBE-q7
+   Xe: GTH-PBE-q8
+   Cs: GTH-PBE-q9
+   Ba: GTH-PBE-q10
+   La: GTH-PBE-q11
+   Ce: GTH-PBE-q12
+   Pr: GTH-PBE-q13
+   Nd: GTH-PBE-q14
+   Pm: GTH-PBE-q15
+   Sm: GTH-PBE-q16
+   Eu: GTH-PBE-q17
+   Gd: GTH-PBE-q18
+   Tb: GTH-PBE-q19
+   Dy: GTH-PBE-q20
+   Ho: GTH-PBE-q21
+   Er: GTH-PBE-q22
+   Tm: GTH-PBE-q23
+   Yb: GTH-PBE-q24
+   Lu: GTH-PBE-q25
+   Hf: GTH-PBE-q12
+   Ta: GTH-PBE-q13
+   W:  GTH-PBE-q14
+   Re: GTH-PBE-q15
+   Os: GTH-PBE-q16
+   Ir: GTH-PBE-q17
+   Pt: GTH-PBE-q18
+   Au: GTH-PBE-q11
+   Hg: GTH-PBE-q12
+   Tl: GTH-PBE-q13
+   Pb: GTH-PBE-q4
+   Bi: GTH-PBE-q5
+   Po: GTH-PBE-q6
+   At: GTH-PBE-q7
+   Rn: GTH-PBE-q8
+
+# Defining input settings
+bandgap_thr_ev: 0.1 #bandgap threshold minimum under which the OT is not considered as valid
+
+settings_0: # main settings exploiting OT
+  GLOBAL:
+    PRINT_LEVEL: MEDIUM              #default: MEDIUM. Important to have the correct parsing
+  FORCE_EVAL:
+    METHOD:         QUICKSTEP
+    STRESS_TENSOR:  ANALYTICAL
+    DFT:
+      BASIS_SET_FILE_NAME:
+        - BASIS_MOLOPT
+        - BASIS_MOLOPT_UCL
+      POTENTIAL_FILE_NAME:
+        -  GTH_POTENTIALS
+      UKS:          False
+      CHARGE:       0
+      MULTIPLICITY: 0
+      MGRID:
+        CUTOFF:      300
+        REL_CUTOFF:  30
+        NGRIDS:      4
+      QS:
+        METHOD: GPW
+        EPS_DEFAULT:   1.0E-10
+        EXTRAPOLATION: ASPC
+
+      SCF:
+        MAX_SCF:       50
+        EPS_SCF:       1.0E-7
+        MAX_ITER_LUMO: 10000         # for computing the Band gap
+        OUTER_SCF:
+          MAX_SCF:   5
+          EPS_SCF:   1.0E-7          # equal (or smaller for expert use) than SCF/EPS_SCF
+        OT:
+          PRECONDITIONER: FULL_ALL
+          MINIMIZER:      DIIS
+
+        MIXING:
+          METHOD: DIRECT_P_MIXING
+          ALPHA:  0.4
+          BETA:   0.5
+      XC:
+        XC_FUNCTIONAL:
+          PBE:
+            PARAMETRIZATION: ORIG
+        VDW_POTENTIAL:
+           POTENTIAL_TYPE:  PAIR_POTENTIAL
+           PAIR_POTENTIAL:
+              PARAMETER_FILE_NAME:   dftd3.dat
+              TYPE:                  DFTD3(BJ)
+              REFERENCE_FUNCTIONAL:   PBE
+      PRINT:
+        MO_CUBES:
+          WRITE_CUBE: F
+          ADD_LAST: SYMBOLIC
+          EACH:
+            CELL_OPT: 0
+            GEO_OPT: 0
+            MD: 0
+          NHOMO: 1  # all eigenvalues are dumped anyway
+          NLUMO: 1  # specified neigenvalues are dupmed
+        MULLIKEN:
+          _: 'ON'
+          ADD_LAST: SYMBOLIC
+          EACH:
+            CELL_OPT: 0
+            GEO_OPT: 0
+            MD: 0
+        LOWDIN:
+          _: 'OFF'
+        HIRSHFELD:
+          _: 'OFF'
+
+  MOTION:
+    PRINT:
+      TRAJECTORY:
+        FORMAT: DCD_ALIGNED_CELL
+        EACH:
+          CELL_OPT: 1
+          GEO_OPT: 1
+          MD: 1
+      RESTART:
+        BACKUP_COPIES: 0
+        EACH:
+          CELL_OPT: 1
+          GEO_OPT: 1
+          MD: 1
+      RESTART_HISTORY:
+        _: OFF
+      CELL:
+        _: OFF
+      VELOCITIES:
+        _: OFF
+      FORCES:
+        _: OFF
+      STRESS:
+        _: OFF
+
+settings_1: # alternative settings #1, using smearing+diagonalization
+  FORCE_EVAL:
+    DFT:
+      QS:
+        EXTRAPOLATION: USE_PREV_WF  #ASPC not good wioth smearing
+      SCF:
+        MAX_SCF: 500
+        ADDED_MOS: 100
+        SMEAR:
+          _:  ON
+          METHOD: FERMI_DIRAC
+          ELECTRONIC_TEMPERATURE: '[K] 300'
+        DIAGONALIZATION:
+          ALGORITHM: STANDARD
+        OT:
+          _: False
+        OUTER_SCF:
+          _: False
+        MIXING:
+          METHOD: BROYDEN_MIXING
+          ALPHA: 0.4
+          NBROYDEN: 8
+
+# Defining stage's settings (relative to the &MOTION)
+stage_0:
+  GLOBAL:
+    RUN_TYPE: GEO_OPT
+  MOTION:
+    GEO_OPT:
+      TYPE: MINIMIZATION                     #default: MINIMIZATION
+      OPTIMIZER: BFGS                        #default: BFGS
+      MAX_ITER:  2                           #default: 200
+      MAX_DR:    "[bohr] 0.0030"             #default: [bohr] 0.0030
+      RMS_DR:    "[bohr] 0.0015"             #default: [bohr] 0.0015
+      MAX_FORCE: "[bohr^-1*hartree] 0.00045"  #default: [bohr^-1*hartree] 0.00045
+      RMS_FORCE: "[bohr^-1*hartree] 0.00030"  #default: [bohr^-1*hartree] 0.00030
+      BFGS:
+          TRUST_RADIUS: "[angstrom] 0.25"      #default: [angstrom] 0.25
+
+stage_1:
+  GLOBAL:
+    RUN_TYPE: MD
+  MOTION:
+    MD:
+      ENSEMBLE:        NVT
+      STEPS:           2
+      TIMESTEP: "[fs]  1.0"
+      TEMPERATURE:    300
+      THERMOSTAT:
+        TYPE: CSVR
+        CSVR:
+          TIMECON: "[fs] 100"

--- a/aiida_lsmo/workchains/isotherm.py
+++ b/aiida_lsmo/workchains/isotherm.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Isotherm workchain"""
 
 import os

--- a/aiida_lsmo/workchains/isotherm_calc_pe.py
+++ b/aiida_lsmo/workchains/isotherm_calc_pe.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """IsothermCalcPE work chain."""
 
 from aiida.plugins import DataFactory, WorkflowFactory

--- a/aiida_lsmo/workchains/isotherm_multi_temp.py
+++ b/aiida_lsmo/workchains/isotherm_multi_temp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """IsothermMultiTemp workchain."""
 
 from aiida.plugins import WorkflowFactory

--- a/aiida_lsmo/workchains/multistage_ddec.py
+++ b/aiida_lsmo/workchains/multistage_ddec.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """MultistageDdecWorkChain workchain"""
 
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory

--- a/aiida_lsmo/workchains/nanoporous_screening_1.py
+++ b/aiida_lsmo/workchains/nanoporous_screening_1.py
@@ -6,7 +6,7 @@ from aiida.common import AttributeDict
 from aiida.engine import WorkChain, ToContext
 
 # import sub-workchains
-ZeoppMultistageDdecWorkChain = WorkflowFactory('lsmo.zeoppmultistageddec')  # pylint: disable=invalid-name
+ZeoppMultistageDdecWorkChain = WorkflowFactory('lsmo.zeopp_multistage_ddec')  # pylint: disable=invalid-name
 IsothermCalcPEWorkChain = WorkflowFactory('lsmo.isotherm_calc_pe')  # pylint: disable=invalid-name
 
 

--- a/aiida_lsmo/workchains/nanoporous_screening_1.py
+++ b/aiida_lsmo/workchains/nanoporous_screening_1.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """ZeoppMultistageDdecPeWorkChain workchain"""
 
 from aiida.orm import Group

--- a/aiida_lsmo/workchains/sim_annealing.py
+++ b/aiida_lsmo/workchains/sim_annealing.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Isotherm workchain"""
 
 import os

--- a/aiida_lsmo/workchains/zeopp_multistage_ddec.py
+++ b/aiida_lsmo/workchains/zeopp_multistage_ddec.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """ZeoppMultistageDdecWorkChain work chain"""
 
 from aiida.plugins import CalculationFactory, DataFactory, WorkflowFactory

--- a/docs/source/apidoc/aiida_lsmo.parsers.rst
+++ b/docs/source/apidoc/aiida_lsmo.parsers.rst
@@ -1,0 +1,26 @@
+aiida\_lsmo.parsers package
+===========================
+
+Submodules
+----------
+
+aiida\_lsmo.parsers.parser\_functions module
+--------------------------------------------
+
+.. automodule:: aiida_lsmo.parsers.parser_functions
+   :members:
+   :special-members:
+   :private-members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: aiida_lsmo.parsers
+   :members:
+   :special-members:
+   :private-members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/apidoc/aiida_lsmo.rst
+++ b/docs/source/apidoc/aiida_lsmo.rst
@@ -7,6 +7,7 @@ Subpackages
 .. toctree::
 
    aiida_lsmo.calcfunctions
+   aiida_lsmo.parsers
    aiida_lsmo.utils
    aiida_lsmo.workchains
 

--- a/docs/source/apidoc/aiida_lsmo.utils.rst
+++ b/docs/source/apidoc/aiida_lsmo.utils.rst
@@ -4,6 +4,16 @@ aiida\_lsmo.utils package
 Submodules
 ----------
 
+aiida\_lsmo.utils.cp2k\_utils module
+------------------------------------
+
+.. automodule:: aiida_lsmo.utils.cp2k_utils
+   :members:
+   :special-members:
+   :private-members:
+   :undoc-members:
+   :show-inheritance:
+
 aiida\_lsmo.utils.multiply\_unitcell module
 -------------------------------------------
 

--- a/docs/source/apidoc/aiida_lsmo.workchains.rst
+++ b/docs/source/apidoc/aiida_lsmo.workchains.rst
@@ -24,6 +24,26 @@ aiida\_lsmo.workchains.cp2k\_binding\_energy module
    :undoc-members:
    :show-inheritance:
 
+aiida\_lsmo.workchains.cp2k\_multistage module
+----------------------------------------------
+
+.. automodule:: aiida_lsmo.workchains.cp2k_multistage
+   :members:
+   :special-members:
+   :private-members:
+   :undoc-members:
+   :show-inheritance:
+
+aiida\_lsmo.workchains.cp2k\_multistage\_ddec module
+----------------------------------------------------
+
+.. automodule:: aiida_lsmo.workchains.cp2k_multistage_ddec
+   :members:
+   :special-members:
+   :private-members:
+   :undoc-members:
+   :show-inheritance:
+
 aiida\_lsmo.workchains.isotherm module
 --------------------------------------
 
@@ -48,16 +68,6 @@ aiida\_lsmo.workchains.isotherm\_multi\_temp module
 ---------------------------------------------------
 
 .. automodule:: aiida_lsmo.workchains.isotherm_multi_temp
-   :members:
-   :special-members:
-   :private-members:
-   :undoc-members:
-   :show-inheritance:
-
-aiida\_lsmo.workchains.multistage\_ddec module
-----------------------------------------------
-
-.. automodule:: aiida_lsmo.workchains.multistage_ddec
    :members:
    :special-members:
    :private-members:

--- a/docs/source/workflows.rst
+++ b/docs/source/workflows.rst
@@ -75,7 +75,7 @@ An example is :py:func:`~aiida_lsmo.calcfunctions.working_cap.calc_ch4_working_c
 Isotherm work chain
 +++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.IsothermWorkChain` work function allows to compute a single-component
+The :py:func:`~aiida_lsmo.workchains.isotherm.IsothermWorkChain` work function allows to compute a single-component
 isotherm in a framework, from a few settings.
 
 What it does, in order:
@@ -243,7 +243,7 @@ selection of the work chain is skipped.
 IsothermMultiTemp work chain
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.IsothermMultiTempWorkChain` work chain can run in parallel the
+The :py:func:`~aiida_lsmo.workchains.isotherm_multi_temp.IsothermMultiTempWorkChain` work chain can run in parallel the
 Isotherm work chain at different temperatures. Since the
 geometry initial calculation to get the pore volume and blocking spheres is not dependent on the temperature, this is
 run only once. Inputs and outputs are very similar to the Isotherm work chain.
@@ -438,7 +438,7 @@ What it can not do:
 IosthermCalcPE work chain
 ++++++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.IsothermCalcPEWorkChain` work chain takes as an input a structure
+The :py:func:`~aiida_lsmo.workchains.isotherm_calc_pe.IsothermCalcPEWorkChain` work chain takes as an input a structure
 with partial charges, computes the isotherms for CO2 and N2 at
 ambient temperature and models the process of carbon capture and compression for geological sequestration.
 The final outcome informs about the performance of the adsorbent for this application, including the CO2 parasitic energy,
@@ -451,7 +451,7 @@ Default input mixture is coal post-combustion flue gas, but also natural gas pos
 Multistage work chain
 ++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.Cp2kMultistageWorkChain` work chain in meant to automate 
+The :py:func:`~aiida_lsmo.workchains.cp2k_multistage.Cp2kMultistageWorkChain` work chain in meant to automate 
 DFT optimizations in CP2K and guess some good parameters
 for the simulation, but it is written in such a versatile fashion that it can be used for many other functions.
 
@@ -719,7 +719,7 @@ The report provides very useful insight on what happened during the run. Here it
 Cp2kMultistageDdec work chain
 ++++++++++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.Cp2kMultistageDdecWorkChain` work chain combines together the CP2K
+The :py:func:`~aiida_lsmo.workchains.cp2k_multistage_ddec.Cp2kMultistageDdecWorkChain` work chain combines together the CP2K
 Multistage workchain and the DDEC calculation, with the scope of
 optimizing the geometry of a structure and compute its partial charge using the DDEC protocol.
 
@@ -729,7 +729,7 @@ optimizing the geometry of a structure and compute its partial charge using the 
 ZeoppMultistageDdec work chain
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.ZeoppMultistageDdecWorkChain` work chain, is similar to Cp2kMultistageDdec
+The :py:func:`~aiida_lsmo.workchains.zeopp_multistage_ddec.ZeoppMultistageDdecWorkChain` work chain, is similar to Cp2kMultistageDdec
 but it runs a geometry characterization of the structure
 using Zeo++ (NetworkCalculation) before and after, with the scope of assessing the structural changes due to the cell/geometry
 optimization.
@@ -740,7 +740,7 @@ optimization.
 SimAnnealing work chain
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.SimAnnealingWorkChain` work chain
+The :py:func:`~aiida_lsmo.workchains.sim_annealing.SimAnnealingWorkChain` work chain
 allows to find the minimum configuration a number of gas molecules, in the pore volume of a framework.
 It runs several NVT simulations in RASPA at decreasing temperature to make the system move to its global minimum (simulated annealing),
 and it finally performs a minimization for the final fine tuning of the optimum position.
@@ -816,7 +816,7 @@ and it finally performs a minimization for the final fine tuning of the optimum 
 Cp2kBindingEnergy work chain
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.Cp2kBindingEnergyWorkChain` work chain
+The :py:func:`~aiida_lsmo.workchains.cp2k_binding_energy.Cp2kBindingEnergyWorkChain` work chain
 takes as an input a CIF structure and the initial position of a molecule in its pore,
 optimizes the molecule's geometry keeping the framework rigid and computes the BSSE corrected interactions energy.
 The work chain is similar to CP2K's MulstistageWorkChain in reading the settings from YAML protocol,
@@ -897,9 +897,9 @@ Look at the inputs details of the Multistage work chain for more information abo
 BindingSiteWorkChain work chain
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.BindingSiteWorkChain` work chain
-simply combines :py:func:`~aiida_lsmo.workchains.SimAnnealingWorkChain`
-and :py:func:`~aiida_lsmo.workchains.Cp2kBindingEnergyWorkChain`.
+The :py:func:`~aiida_lsmo.workchains.binding_site.BindingSiteWorkChain` work chain
+simply combines :py:func:`~aiida_lsmo.workchains.sim_annealing.SimAnnealingWorkChain`
+and :py:func:`~aiida_lsmo.workchains.cp2k_binding_energy.Cp2kBindingEnergyWorkChain`.
 The outputs from the two workchain are collected under the ``ff`` and ``dft`` namespaces, respectively.
 
 .. aiida-workchain:: BindingSiteWorkChain

--- a/docs/source/workflows.rst
+++ b/docs/source/workflows.rst
@@ -75,7 +75,7 @@ An example is :py:func:`~aiida_lsmo.calcfunctions.working_cap.calc_ch4_working_c
 Isotherm work chain
 +++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.isotherm.IsothermWorkChain` work function allows to compute a single-component
+The :py:func:`~aiida_lsmo.workchains.IsothermWorkChain` work function allows to compute a single-component
 isotherm in a framework, from a few settings.
 
 What it does, in order:
@@ -243,7 +243,7 @@ selection of the work chain is skipped.
 IsothermMultiTemp work chain
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.isotherm_multi_temp.IsothermMultiTempWorkChain` work chain can run in parallel the
+The :py:func:`~aiida_lsmo.workchains.IsothermMultiTempWorkChain` work chain can run in parallel the
 Isotherm work chain at different temperatures. Since the
 geometry initial calculation to get the pore volume and blocking spheres is not dependent on the temperature, this is
 run only once. Inputs and outputs are very similar to the Isotherm work chain.
@@ -438,7 +438,7 @@ What it can not do:
 IosthermCalcPE work chain
 ++++++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.isotherm_calc_pe.IsothermCalcPEWorkChain` work chain takes as an input a structure
+The :py:func:`~aiida_lsmo.workchains.IsothermCalcPEWorkChain` work chain takes as an input a structure
 with partial charges, computes the isotherms for CO2 and N2 at
 ambient temperature and models the process of carbon capture and compression for geological sequestration.
 The final outcome informs about the performance of the adsorbent for this application, including the CO2 parasitic energy,
@@ -451,9 +451,8 @@ Default input mixture is coal post-combustion flue gas, but also natural gas pos
 Multistage work chain
 ++++++++++++++++++++++
 
-*NOTE: this work chain is part of the `<aiida-cp2k https://github.com/aiidateam/aiida-cp2k>`_ plugin*
-
-The ``MulstistageWorkChain`` work chain in meant to automate DFT optimizations in CP2K and guess some good parameters
+The :py:func:`~aiida_lsmo.workchains.Cp2kMultistageWorkChain` work chain in meant to automate 
+DFT optimizations in CP2K and guess some good parameters
 for the simulation, but it is written in such a versatile fashion that it can be used for many other functions.
 
 What it can do:
@@ -477,6 +476,9 @@ What it can not do:
 
 #. Run CP2K calculations with k-points.
 #. Run CP2K advanced calculations, e.g., other than ``ENERGY``, ``GEO_OPT``, ``CELL_OPT`` and ``MD``.
+
+.. aiida-workchain:: Cp2kMultistageWorkChain
+    :module: aiida_lsmo.workchains
 
 **Inputs details**
 
@@ -714,20 +716,20 @@ The report provides very useful insight on what happened during the run. Here it
   2019-11-22 16:55:54 [90983 | REPORT]: [266248|Cp2kMultistageWorkChain|inspect_and_update_stage]: All stages computed, finishing...
   2019-11-22 16:55:55 [90984 | REPORT]: [266248|Cp2kMultistageWorkChain|results]: Outputs: Dict<266273> and StructureData<266271>
 
-MultistageDdec work chain
-++++++++++++++++++++++++++
+Cp2kMultistageDdec work chain
+++++++++++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.multistage_ddec.MultistageDdecWorkChain` work chain combines together the CP2K
+The :py:func:`~aiida_lsmo.workchains.Cp2kMultistageDdecWorkChain` work chain combines together the CP2K
 Multistage workchain and the DDEC calculation, with the scope of
 optimizing the geometry of a structure and compute its partial charge using the DDEC protocol.
 
-.. aiida-workchain:: MultistageDdecWorkChain
+.. aiida-workchain:: Cp2kMultistageDdecWorkChain
     :module: aiida_lsmo.workchains
 
 ZeoppMultistageDdec work chain
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.zeopp_multistage_ddec.ZeoppMultistageDdecWorkChain` work chain, is similar to MultistageDdec
+The :py:func:`~aiida_lsmo.workchains.ZeoppMultistageDdecWorkChain` work chain, is similar to Cp2kMultistageDdec
 but it runs a geometry characterization of the structure
 using Zeo++ (NetworkCalculation) before and after, with the scope of assessing the structural changes due to the cell/geometry
 optimization.
@@ -738,7 +740,7 @@ optimization.
 SimAnnealing work chain
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.sim_annealing.SimAnnealingWorkChain` work chain
+The :py:func:`~aiida_lsmo.workchains.SimAnnealingWorkChain` work chain
 allows to find the minimum configuration a number of gas molecules, in the pore volume of a framework.
 It runs several NVT simulations in RASPA at decreasing temperature to make the system move to its global minimum (simulated annealing),
 and it finally performs a minimization for the final fine tuning of the optimum position.
@@ -814,7 +816,7 @@ and it finally performs a minimization for the final fine tuning of the optimum 
 Cp2kBindingEnergy work chain
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.cp2k_binding_energy.Cp2kBindingEnergyWorkChain` work chain
+The :py:func:`~aiida_lsmo.workchains.Cp2kBindingEnergyWorkChain` work chain
 takes as an input a CIF structure and the initial position of a molecule in its pore,
 optimizes the molecule's geometry keeping the framework rigid and computes the BSSE corrected interactions energy.
 The work chain is similar to CP2K's MulstistageWorkChain in reading the settings from YAML protocol,
@@ -895,9 +897,9 @@ Look at the inputs details of the Multistage work chain for more information abo
 BindingSiteWorkChain work chain
 ++++++++++++++++++++++++++++++++++++++++++++++
 
-The :py:func:`~aiida_lsmo.workchains.binding_site.BindingSiteWorkChain` work chain
-simply combines :py:func:`~aiida_lsmo.workchains.sim_annealing.SimAnnealingWorkChain`
-and :py:func:`~aiida_lsmo.workchains.cp2k_binding_energy.Cp2kBindingEnergyWorkChain`.
+The :py:func:`~aiida_lsmo.workchains.BindingSiteWorkChain` work chain
+simply combines :py:func:`~aiida_lsmo.workchains.SimAnnealingWorkChain`
+and :py:func:`~aiida_lsmo.workchains.Cp2kBindingEnergyWorkChain`.
 The outputs from the two workchain are collected under the ``ff`` and ``dft`` namespaces, respectively.
 
 .. aiida-workchain:: BindingSiteWorkChain

--- a/examples/data/Al.cif
+++ b/examples/data/Al.cif
@@ -1,0 +1,27 @@
+data_crystal
+ 
+_cell_length_a    4.04958
+_cell_length_b    4.04958
+_cell_length_c    4.04958
+_cell_angle_alpha 90.00000
+_cell_angle_beta  90.00000
+_cell_angle_gamma 90.00000
+ 
+_symmetry_space_group_name_Hall 'P 1'
+_symmetry_space_group_name_H-M  'P 1'
+ 
+loop_
+_symmetry_equiv_pos_as_xyz
+ 'x,y,z' 
+ 
+loop_
+_atom_site_label
+_atom_site_type_symbol
+_atom_site_fract_x
+_atom_site_fract_y
+_atom_site_fract_z
+_atom_site_charge
+Al         Al      0.00000   0.00000   0.00000   0.0000000000
+Al         Al      0.00000   0.50000   0.50000   0.0000000000
+Al         Al      0.50000   0.00000   0.50000   0.0000000000
+Al         Al      0.50000   0.50000   0.00000   0.0000000000

--- a/examples/data/test_multistage_protocol.yaml
+++ b/examples/data/test_multistage_protocol.yaml
@@ -1,0 +1,394 @@
+# Defining atomic properties
+
+initial_magnetization:
+  H:  0
+  Li: 0  # oxidation state +1
+  Be: 0  # oxidation state +2
+  B:  0
+  C:  0
+  N:  0
+  O:  0
+  F:  0
+  Na: 0  # oxidation state +1
+  Mg: 0  # oxidation state +2
+  Al: 0  # oxidation state +3
+  Si: 0
+  P:  0
+  S:  0
+  Cl: 0
+  K:  0  # oxidation state +1
+  Ca: 0  # oxidation state +2
+  Sc: 0  # oxidation state +1
+  Ti: 0  # oxidation state +4
+  V:  3  # oxidation state +2 high spin
+  Cr: 4  # oxidation state +2 high spin
+  Mn: 5  # oxidation state +2 high spin
+  Fe: 4  # oxidation state +2 high spin
+  Co: 3  # oxidation state +2 high spin
+  Ni: 2  # oxidation state +2 high spin
+  Cu: 1  # oxidation state +2 high spin
+  Zn: 0  # oxidation state +2
+  Zr: 0  # oxidation state +4
+
+basis_set:
+  H:  DZVP-MOLOPT-SR-GTH-q1
+  He: DZVP-MOLOPT-SR-GTH-q2
+  Li: DZVP-MOLOPT-SR-GTH-q3
+  Be: DZVP-MOLOPT-SR-GTH-q4
+  B:  DZVP-MOLOPT-SR-GTH-q3
+  C:  DZVP-MOLOPT-SR-GTH-q4
+  N:  DZVP-MOLOPT-SR-GTH-q5
+  O:  DZVP-MOLOPT-SR-GTH-q6
+  F:  DZVP-MOLOPT-SR-GTH-q7
+  Ne: DZVP-MOLOPT-SR-GTH-q8
+  Na: DZVP-MOLOPT-SR-GTH-q9
+  Mg: DZVP-MOLOPT-SR-GTH-q2
+  Al: DZVP-MOLOPT-SR-GTH-q3
+  Si: DZVP-MOLOPT-SR-GTH-q4
+  P:  DZVP-MOLOPT-SR-GTH-q5
+  S:  DZVP-MOLOPT-SR-GTH-q6
+  Cl: DZVP-MOLOPT-SR-GTH-q7
+  Ar: DZVP-MOLOPT-SR-GTH-q8
+  K:  DZVP-MOLOPT-SR-GTH-q9
+  Ca: DZVP-MOLOPT-SR-GTH-q10
+  Sc: DZVP-MOLOPT-SR-GTH-q11
+  Ti: DZVP-MOLOPT-SR-GTH-q12
+  V:  DZVP-MOLOPT-SR-GTH-q13
+  Cr: DZVP-MOLOPT-SR-GTH-q14
+  Mn: DZVP-MOLOPT-SR-GTH-q15
+  Fe: DZVP-MOLOPT-SR-GTH-q16
+  Co: DZVP-MOLOPT-SR-GTH-q17
+  Ni: DZVP-MOLOPT-SR-GTH-q18
+  Cu: DZVP-MOLOPT-SR-GTH-q11
+  Zn: DZVP-MOLOPT-SR-GTH-q12
+  Ga: DZVP-MOLOPT-SR-GTH-q13
+  Ge: DZVP-MOLOPT-SR-GTH-q4
+  As: DZVP-MOLOPT-SR-GTH-q5
+  Se: DZVP-MOLOPT-SR-GTH-q6
+  Br: DZVP-MOLOPT-SR-GTH-q7
+  Kr: DZVP-MOLOPT-SR-GTH-q8
+  Rb: DZVP-MOLOPT-SR-GTH-q9
+  Sr: DZVP-MOLOPT-SR-GTH-q10
+  Y:  DZVP-MOLOPT-SR-GTH-q11
+  Zr: DZVP-MOLOPT-SR-GTH-q12
+  Nb: DZVP-MOLOPT-SR-GTH-q13
+  Mo: DZVP-MOLOPT-SR-GTH-q14
+  Tc: DZVP-MOLOPT-SR-GTH-q15
+  Ru: DZVP-MOLOPT-SR-GTH-q16
+  Rh: DZVP-MOLOPT-SR-GTH-q9
+  Pd: DZVP-MOLOPT-SR-GTH-q18
+  Ag: DZVP-MOLOPT-SR-GTH-q11
+  Cd: DZVP-MOLOPT-SR-GTH-q12
+  In: DZVP-MOLOPT-SR-GTH-q13
+  Sn: DZVP-MOLOPT-SR-GTH-q4
+  Sb: DZVP-MOLOPT-SR-GTH-q5
+  Te: DZVP-MOLOPT-SR-GTH-q6
+  I:  DZVP-MOLOPT-SR-GTH-q7
+  Xe: DZVP-MOLOPT-SR-GTH-q8
+  Cs: DZVP-MOLOPT-SR-GTH-q9
+  Ba: DZVP-MOLOPT-SR-GTH-q10
+  La: DZVP-MOLOPT-SR-GTH-q11
+  Ce: DZVP-MOLOPT-SR-GTH-q12
+  Pr: DZVP-MOLOPT-SR-GTH-q13
+  Nd: DZVP-MOLOPT-SR-GTH-q14
+  Pm: DZVP-MOLOPT-SR-GTH-q15
+  Sm: DZVP-MOLOPT-SR-GTH-q16
+  Eu: DZVP-MOLOPT-SR-GTH-q17
+  Gd: DZVP-MOLOPT-SR-GTH-q18
+  Tb: DZVP-MOLOPT-SR-GTH-q19
+  Dy: DZVP-MOLOPT-SR-GTH-q20
+  Ho: DZVP-MOLOPT-SR-GTH-q21
+  Er: DZVP-MOLOPT-SR-GTH-q22
+  Tm: DZVP-MOLOPT-SR-GTH-q23
+  Yb: DZVP-MOLOPT-SR-GTH-q24
+  Lu: DZVP-MOLOPT-SR-GTH-q25
+  Hf: DZVP-MOLOPT-SR-GTH-q12
+  Ta: DZVP-MOLOPT-SR-GTH-q13
+  W:  DZVP-MOLOPT-SR-GTH-q14
+  Re: DZVP-MOLOPT-SR-GTH-q15
+  Os: DZVP-MOLOPT-SR-GTH-q16
+  Ir: DZVP-MOLOPT-SR-GTH-q17
+  Pt: DZVP-MOLOPT-SR-GTH-q18
+  Au: DZVP-MOLOPT-SR-GTH-q11
+  Hg: DZVP-MOLOPT-SR-GTH-q12
+  Tl: DZVP-MOLOPT-SR-GTH-q13
+  Pb: DZVP-MOLOPT-SR-GTH-q4
+  Bi: DZVP-MOLOPT-SR-GTH-q5
+  Po: DZVP-MOLOPT-SR-GTH-q6
+  At: DZVP-MOLOPT-SR-GTH-q7
+  Rn: DZVP-MOLOPT-SR-GTH-q8
+
+pseudopotential:
+   H:  GTH-PBE-q1
+   He: GTH-PBE-q2
+   Li: GTH-PBE-q3
+   Be: GTH-PBE-q4
+   B:  GTH-PBE-q3
+   C:  GTH-PBE-q4
+   N:  GTH-PBE-q5
+   O:  GTH-PBE-q6
+   F:  GTH-PBE-q7
+   Ne: GTH-PBE-q8
+   Na: GTH-PBE-q9
+   Mg: GTH-PBE-q2
+   Al: GTH-PBE-q3
+   Si: GTH-PBE-q4
+   P:  GTH-PBE-q5
+   S:  GTH-PBE-q6
+   Cl: GTH-PBE-q7
+   Ar: GTH-PBE-q8
+   K:  GTH-PBE-q9
+   Ca: GTH-PBE-q10
+   Sc: GTH-PBE-q11
+   Ti: GTH-PBE-q12
+   V:  GTH-PBE-q13
+   Cr: GTH-PBE-q14
+   Mn: GTH-PBE-q15
+   Fe: GTH-PBE-q16
+   Co: GTH-PBE-q17
+   Ni: GTH-PBE-q18
+   Cu: GTH-PBE-q11
+   Zn: GTH-PBE-q12
+   Ga: GTH-PBE-q13
+   Ge: GTH-PBE-q4
+   As: GTH-PBE-q5
+   Se: GTH-PBE-q6
+   Br: GTH-PBE-q7
+   Kr: GTH-PBE-q8
+   Rb: GTH-PBE-q9
+   Sr: GTH-PBE-q10
+   Y:  GTH-PBE-q11
+   Zr: GTH-PBE-q12
+   Nb: GTH-PBE-q13
+   Mo: GTH-PBE-q14
+   Tc: GTH-PBE-q15
+   Ru: GTH-PBE-q16
+   Rh: GTH-PBE-q9
+   Pd: GTH-PBE-q18
+   Ag: GTH-PBE-q11
+   Cd: GTH-PBE-q12
+   In: GTH-PBE-q13
+   Sn: GTH-PBE-q4
+   Sb: GTH-PBE-q5
+   Te: GTH-PBE-q6
+   I:  GTH-PBE-q7
+   Xe: GTH-PBE-q8
+   Cs: GTH-PBE-q9
+   Ba: GTH-PBE-q10
+   La: GTH-PBE-q11
+   Ce: GTH-PBE-q12
+   Pr: GTH-PBE-q13
+   Nd: GTH-PBE-q14
+   Pm: GTH-PBE-q15
+   Sm: GTH-PBE-q16
+   Eu: GTH-PBE-q17
+   Gd: GTH-PBE-q18
+   Tb: GTH-PBE-q19
+   Dy: GTH-PBE-q20
+   Ho: GTH-PBE-q21
+   Er: GTH-PBE-q22
+   Tm: GTH-PBE-q23
+   Yb: GTH-PBE-q24
+   Lu: GTH-PBE-q25
+   Hf: GTH-PBE-q12
+   Ta: GTH-PBE-q13
+   W:  GTH-PBE-q14
+   Re: GTH-PBE-q15
+   Os: GTH-PBE-q16
+   Ir: GTH-PBE-q17
+   Pt: GTH-PBE-q18
+   Au: GTH-PBE-q11
+   Hg: GTH-PBE-q12
+   Tl: GTH-PBE-q13
+   Pb: GTH-PBE-q4
+   Bi: GTH-PBE-q5
+   Po: GTH-PBE-q6
+   At: GTH-PBE-q7
+   Rn: GTH-PBE-q8
+
+# Defining input settings
+bandgap_thr_ev: 0.1 #bandgap threshold minimum under which the OT is not considered as valid
+
+settings_0: # main settings exploiting OT
+  GLOBAL:
+    PRINT_LEVEL: MEDIUM              #default: MEDIUM. Important to have the correct parsing
+  FORCE_EVAL:
+    METHOD:         QUICKSTEP
+    STRESS_TENSOR:  ANALYTICAL
+    DFT:
+      BASIS_SET_FILE_NAME:
+        - BASIS_MOLOPT
+        - BASIS_MOLOPT_UCL
+      POTENTIAL_FILE_NAME:
+        -  GTH_POTENTIALS
+      UKS:          False
+      CHARGE:       0
+      MULTIPLICITY: 0
+      MGRID:
+        CUTOFF:      300
+        REL_CUTOFF:  30
+        NGRIDS:      4
+      QS:
+        METHOD: GPW
+        EPS_DEFAULT:   1.0E-10
+        EXTRAPOLATION: ASPC
+
+      SCF:
+        MAX_SCF:       50
+        EPS_SCF:       1.0E-7
+        MAX_ITER_LUMO: 10000         # for computing the Band gap
+        OUTER_SCF:
+          MAX_SCF:   5
+          EPS_SCF:   1.0E-7          # equal (or smaller for expert use) than SCF/EPS_SCF
+        OT:
+          PRECONDITIONER: FULL_ALL
+          MINIMIZER:      DIIS
+
+        MIXING:
+          METHOD: DIRECT_P_MIXING
+          ALPHA:  0.4
+          BETA:   0.5
+      XC:
+        XC_FUNCTIONAL:
+          PBE:
+            PARAMETRIZATION: ORIG
+        VDW_POTENTIAL:
+           POTENTIAL_TYPE:  PAIR_POTENTIAL
+           PAIR_POTENTIAL:
+              PARAMETER_FILE_NAME:   dftd3.dat
+              TYPE:                  DFTD3(BJ)
+              REFERENCE_FUNCTIONAL:   PBE
+      PRINT:
+        MO_CUBES:
+          WRITE_CUBE: F
+          ADD_LAST: SYMBOLIC
+          EACH:
+            CELL_OPT: 0
+            GEO_OPT: 0
+            MD: 0
+          NHOMO: 1  # all eigenvalues are dumped anyway
+          NLUMO: 1  # specified neigenvalues are dupmed
+        MULLIKEN:
+          _: 'ON'
+          ADD_LAST: SYMBOLIC
+          EACH:
+            CELL_OPT: 0
+            GEO_OPT: 0
+            MD: 0
+        LOWDIN:
+          _: 'OFF'
+        HIRSHFELD:
+          _: 'OFF'
+
+  MOTION:
+    PRINT:
+      TRAJECTORY:
+        FORMAT: DCD_ALIGNED_CELL
+        EACH:
+          CELL_OPT: 1
+          GEO_OPT: 1
+          MD: 1
+      RESTART:
+        BACKUP_COPIES: 0
+        EACH:
+          CELL_OPT: 1
+          GEO_OPT: 1
+          MD: 1
+      RESTART_HISTORY:
+        _: OFF
+      CELL:
+        _: OFF
+      VELOCITIES:
+        _: OFF
+      FORCES:
+        _: OFF
+      STRESS:
+        _: OFF
+
+settings_1: # alternative settings #1, using smearing+diagonalization
+  FORCE_EVAL:
+    DFT:
+      QS:
+        EXTRAPOLATION: USE_PREV_WF  #ASPC not good wioth smearing
+      SCF:
+        MAX_SCF: 500
+        ADDED_MOS: 1000
+        SMEAR:
+          _:  ON
+          METHOD: FERMI_DIRAC
+          ELECTRONIC_TEMPERATURE: '[K] 300'
+        DIAGONALIZATION:
+          ALGORITHM: STANDARD
+        OT:
+          _: False
+        OUTER_SCF:
+          _: False
+        MIXING:
+          METHOD: BROYDEN_MIXING
+          ALPHA: 0.4
+          NBROYDEN: 8
+
+# Defining stage's settings (relative to the &MOTION)
+stage_0:
+  GLOBAL:
+    RUN_TYPE: GEO_OPT
+  MOTION:
+    GEO_OPT:
+      TYPE: MINIMIZATION                     #default: MINIMIZATION
+      OPTIMIZER: BFGS                        #default: BFGS
+      MAX_ITER:  2                           #default: 200
+      MAX_DR:    "[bohr] 0.0030"             #default: [bohr] 0.0030
+      RMS_DR:    "[bohr] 0.0015"             #default: [bohr] 0.0015
+      MAX_FORCE: "[bohr^-1*hartree] 0.00045"  #default: [bohr^-1*hartree] 0.00045
+      RMS_FORCE: "[bohr^-1*hartree] 0.00030"  #default: [bohr^-1*hartree] 0.00030
+      BFGS:
+          TRUST_RADIUS: "[angstrom] 0.25"      #default: [angstrom] 0.25
+
+stage_1:
+  GLOBAL:
+    RUN_TYPE: MD
+  MOTION:
+    MD:
+      ENSEMBLE:        NVT
+      STEPS:           2
+      TIMESTEP: "[fs]  1.0"
+      TEMPERATURE:    300
+      THERMOSTAT:
+        TYPE: CSVR
+        CSVR:
+          TIMECON: "[fs] 100"      ### SLing: 0.1 small time constant (strong coupling) for equilibration; change to 50~100 or bigger for production run
+
+#excluded stages (to be activated for testing issues)
+excluded_stage_2alt:
+  GLOBAL:
+    RUN_TYPE: GEO_OPT
+  MOTION:
+    GEO_OPT:
+      TYPE: MINIMIZATION                     #default: MINIMIZATION
+      OPTIMIZER: LBFGS                        #default: BFGS
+      MAX_ITER:  2                        #default: 200
+      MAX_DR:    "[bohr] 0.0030"             #default: [bohr] 0.0030
+      RMS_DR:    "[bohr] 0.0015"             #default: [bohr] 0.0015
+      MAX_FORCE: "[bohr^-1*hartree] 0.00045"  #default: [bohr^-1*hartree] 0.00045
+      RMS_FORCE: "[bohr^-1*hartree] 0.00030"  #default: [bohr^-1*hartree] 0.00030
+      LBFGS:
+          TRUST_RADIUS: "[angstrom] 0.5"
+
+excluded_stage_3:
+  GLOBAL:
+    RUN_TYPE: CELL_OPT
+  MOTION:
+    CELL_OPT:
+      TYPE: DIRECT_CELL_OPT                  #default: DIRECT_CELL_OPT
+      EXTERNAL_PRESSURE: "[bar] 0.0"
+      PRESSURE_TOLERANCE: "[bar] 1000"        #default: 100
+      KEEP_ANGLES:   True
+      KEEP_SYMMETRY: False
+      OPTIMIZER: BFGS                        #default: BFGS
+      MAX_ITER:  2                         #default: 200
+      MAX_DR:    "[bohr] 0.030"             #default: [bohr] 0.0030
+      RMS_DR:    "[bohr] 0.015"             #default: [bohr] 0.0015
+      MAX_FORCE: "[bohr^-1*hartree] 0.045"  #default: [bohr^-1*hartree] 0.00045
+      RMS_FORCE: "[bohr^-1*hartree] 0.030"  #default: [bohr^-1*hartree] 0.00030
+      BFGS:
+        TRUST_RADIUS: "[angstrom] 0.25"

--- a/examples/run_Cp2kMultistageDdecWorkChain_h2o.py
+++ b/examples/run_Cp2kMultistageDdecWorkChain_h2o.py
@@ -10,7 +10,7 @@ from aiida.plugins import DataFactory, WorkflowFactory
 from aiida.orm import Code, Dict, Str
 
 # Workchain object
-MultistageDdecWorkChain = WorkflowFactory('lsmo.multistage_ddec')  # pylint: disable=invalid-name
+MultistageDdecWorkChain = WorkflowFactory('lsmo.cp2k_multistage_ddec')  # pylint: disable=invalid-name
 
 # Data objects
 StructureData = DataFactory('structure')  # pylint: disable=invalid-name
@@ -22,7 +22,7 @@ StructureData = DataFactory('structure')  # pylint: disable=invalid-name
 @click.argument('ddec_atdens_path')
 def main(cp2k_code_string, ddec_code_string, ddec_atdens_path):
     """Example usage:
-    ATDENS_PATH='/home/daniele/Programs/aiida-database/data/chargemol_09_26_2017/atomic_densities/'
+    ATDENS_PATH='/home/daniele/aiida-lsmo-codes/data/chargemol/atomic_densities/'
     verdi run run_Cp2kMultistageDdecWorkChain_h2o.py cp2k@localhost ddec@localhost $ATDENS_PATH
     """
     print('Testing CP2K-Multistage calculation + DDEC on H2O...')

--- a/examples/run_Cp2kMultistageDdecWorkChain_h2o.py
+++ b/examples/run_Cp2kMultistageDdecWorkChain_h2o.py
@@ -10,7 +10,7 @@ from aiida.plugins import DataFactory, WorkflowFactory
 from aiida.orm import Code, Dict, Str
 
 # Workchain object
-MultistageDdecWorkChain = WorkflowFactory('lsmo.multistageddec')  # pylint: disable=invalid-name
+MultistageDdecWorkChain = WorkflowFactory('lsmo.multistage_ddec')  # pylint: disable=invalid-name
 
 # Data objects
 StructureData = DataFactory('structure')  # pylint: disable=invalid-name

--- a/examples/run_ZeoppMultistageDdecWorkChain_H2O.py
+++ b/examples/run_ZeoppMultistageDdecWorkChain_H2O.py
@@ -10,7 +10,7 @@ from aiida.plugins import DataFactory, WorkflowFactory
 from aiida.orm import Code, Dict, Str
 
 # Workchain objects
-ZeoppMultistageDdecWorkChain = WorkflowFactory('lsmo.zeoppmultistageddec')  # pylint: disable=invalid-name
+ZeoppMultistageDdecWorkChain = WorkflowFactory('lsmo.zeopp_multistage_ddec')  # pylint: disable=invalid-name
 
 #Data objects
 CifData = DataFactory('cif')  # pylint: disable=invalid-name

--- a/examples/run_multistage_aluminum.py
+++ b/examples/run_multistage_aluminum.py
@@ -1,0 +1,74 @@
+"""Test/example for the Cp2kMultistageWorkChain."""
+
+import os
+import sys
+import click
+import ase.build
+
+from aiida.engine import run
+from aiida.orm import Code, Dict, StructureData, Str, Int
+from aiida.common import NotExistent
+from aiida.plugins import WorkflowFactory
+
+Cp2kMultistageWorkChain = WorkflowFactory('lsmo.cp2k_multistage')  # pylint: disable=invalid-name
+
+
+def run_multistage_al(cp2k_code):
+    """Example usage: verdi run thistest.py cp2k@localhost"""
+
+    print("Testing CP2K multistage workchain on Al (RKS, needs smearing)...")
+    print("EXPECTED: the OT (settings_0) will converge to a negative bandgap, then we switch to SMEARING (settings_1)")
+
+    thisdir = os.path.dirname(os.path.abspath(__file__))
+    structure = StructureData(ase=ase.io.read(os.path.join(thisdir, '../data/Al.cif')))
+
+    # testing user change of parameters and protocol
+    parameters = Dict(dict={'FORCE_EVAL': {'DFT': {'MGRID': {'CUTOFF': 250,}}}})
+    protocol_mod = Dict(dict={
+        'initial_magnetization': {
+            'Al': 0
+        },
+        'settings_0': {
+            'FORCE_EVAL': {
+                'DFT': {
+                    'SCF': {
+                        'OUTER_SCF': {
+                            'MAX_SCF': 5,
+                        }
+                    }
+                }
+            }
+        }
+    })
+
+    # Construct process builder
+    builder = Cp2kMultistageWorkChain.get_builder()
+    builder.structure = structure
+    builder.protocol_tag = Str('test')
+    builder.starting_settings_idx = Int(0)
+    builder.protocol_modify = protocol_mod
+    builder.cp2k_base.cp2k.parameters = parameters
+    builder.cp2k_base.cp2k.code = cp2k_code
+    builder.cp2k_base.cp2k.metadata.options.resources = {
+        "num_machines": 1,
+        "num_mpiprocs_per_machine": 1,
+    }
+    builder.cp2k_base.cp2k.metadata.options.max_wallclock_seconds = 1 * 3 * 60
+
+    run(builder)
+
+
+@click.command('cli')
+@click.argument('codelabel')
+def cli(codelabel):
+    """Click interface"""
+    try:
+        code = Code.get_from_string(codelabel)
+    except NotExistent:
+        print("The code '{}' does not exist".format(codelabel))
+        sys.exit(1)
+    run_multistage_al(code)
+
+
+if __name__ == '__main__':
+    cli()  # pylint: disable=no-value-for-parameter

--- a/examples/run_multistage_aluminum.py
+++ b/examples/run_multistage_aluminum.py
@@ -17,10 +17,10 @@ def run_multistage_al(cp2k_code):
     """Example usage: verdi run thistest.py cp2k@localhost"""
 
     print("Testing CP2K multistage workchain on Al (RKS, needs smearing)...")
-    print("EXPECTED: the OT (settings_0) will converge to a negative bandgap, then we switch to SMEARING (settings_1)")
+    print("EXPECTED: the OT (settings_0) will converge to a negative bandgap, then use SMEARING (settings_1)")
 
     thisdir = os.path.dirname(os.path.abspath(__file__))
-    structure = StructureData(ase=ase.io.read(os.path.join(thisdir, '../data/Al.cif')))
+    structure = StructureData(ase=ase.io.read(os.path.join(thisdir, 'data/Al.cif')))
 
     # testing user change of parameters and protocol
     parameters = Dict(dict={'FORCE_EVAL': {'DFT': {'MGRID': {'CUTOFF': 250,}}}})

--- a/examples/run_multistage_h2o.py
+++ b/examples/run_multistage_h2o.py
@@ -1,0 +1,52 @@
+""" Test/example for the Cp2kMultistageWorkChain"""
+
+import sys
+import click
+import ase.build
+
+from aiida.engine import run
+from aiida.orm import Code, StructureData, Str
+from aiida.common import NotExistent
+from aiida.plugins import WorkflowFactory
+
+Cp2kMultistageWorkChain = WorkflowFactory('lsmo.cp2k_multistage')  # pylint: disable=invalid-name
+
+
+def run_multistage_h2o(cp2k_code):
+    """Example usage: verdi run thistest.py cp2k@localhost"""
+
+    print("Testing CP2K multistage workchain on H2O (RKS, no need for smearing)...")
+    print(">>> Using 'test' tag")
+
+    atoms = ase.build.molecule('H2O')
+    atoms.center(vacuum=2.0)
+    structure = StructureData(ase=atoms)
+
+    # Construct process builder
+    builder = Cp2kMultistageWorkChain.get_builder()
+    builder.structure = structure
+    builder.protocol_tag = Str('test')
+    builder.cp2k_base.cp2k.code = cp2k_code
+    builder.cp2k_base.cp2k.metadata.options.resources = {
+        "num_machines": 1,
+        "num_mpiprocs_per_machine": 1,
+    }
+    builder.cp2k_base.cp2k.metadata.options.max_wallclock_seconds = 1 * 3 * 60
+
+    run(builder)
+
+
+@click.command('cli')
+@click.argument('codelabel')
+def cli(codelabel):
+    """Click interface"""
+    try:
+        code = Code.get_from_string(codelabel)
+    except NotExistent:
+        print("The code '{}' does not exist".format(codelabel))
+        sys.exit(1)
+    run_multistage_h2o(code)
+
+
+if __name__ == '__main__':
+    cli()  # pylint: disable=no-value-for-parameter

--- a/examples/run_multistage_h2o_fail.py
+++ b/examples/run_multistage_h2o_fail.py
@@ -1,0 +1,61 @@
+""" Test/example for the Cp2kMultistageWorkChain"""
+
+import sys
+import click
+import ase.build
+
+from aiida.engine import run
+from aiida.orm import Code, Dict, StructureData, Str, Int
+from aiida.common import NotExistent
+from aiida.plugins import WorkflowFactory
+
+Cp2kMultistageWorkChain = WorkflowFactory('lsmo.cp2k_multistage')  # pylint: disable=invalid-name
+
+
+def run_multistage_h2o_fail(cp2k_code):
+    """Example usage: verdi run thistest.py cp2k@localhost"""
+
+    print("Testing CP2K multistage workchain on H2O")
+    print(">>> Making it fail because of an unphysical Multiplicity")
+
+    atoms = ase.build.molecule('H2O')
+    atoms.center(vacuum=2.0)
+    structure = StructureData(ase=atoms)
+
+    parameters = Dict(dict={'FORCE_EVAL': {
+        'DFT': {
+            'UKS': True,
+            'MULTIPLICITY': 666,
+        }
+    }})
+
+    # Construct process builder
+    builder = Cp2kMultistageWorkChain.get_builder()
+    builder.structure = structure
+    builder.protocol_tag = Str('test')
+    builder.cp2k_base.max_iterations = Int(1)
+    builder.cp2k_base.cp2k.parameters = parameters
+    builder.cp2k_base.cp2k.code = cp2k_code
+    builder.cp2k_base.cp2k.metadata.options.resources = {
+        "num_machines": 1,
+        "num_mpiprocs_per_machine": 1,
+    }
+    builder.cp2k_base.cp2k.metadata.options.max_wallclock_seconds = 1 * 3 * 60
+
+    run(builder)
+
+
+@click.command('cli')
+@click.argument('codelabel')
+def cli(codelabel):
+    """Click interface"""
+    try:
+        code = Code.get_from_string(codelabel)
+    except NotExistent:
+        print("The code '{}' does not exist".format(codelabel))
+        sys.exit(1)
+    run_multistage_h2o_fail(code)
+
+
+if __name__ == '__main__':
+    cli()  # pylint: disable=no-value-for-parameter

--- a/examples/run_multistage_h2o_singlepoint.py
+++ b/examples/run_multistage_h2o_singlepoint.py
@@ -1,0 +1,52 @@
+""" Test/example for the Cp2kMultistageWorkChain"""
+
+import sys
+import click
+import ase.build
+
+from aiida.engine import run
+from aiida.orm import Code, StructureData, Str
+from aiida.common import NotExistent
+from aiida.plugins import WorkflowFactory
+
+Cp2kMultistageWorkChain = WorkflowFactory('lsmo.cp2k_multistage')  # pylint: disable=invalid-name
+
+
+def run_multistage_h2o_singlepoint(cp2k_code):
+    """Example usage: verdi run thistest.py cp2k@localhost"""
+
+    print("Testing CP2K multistage workchain on H2O")
+    print(">>> Using 'singlepoint' tag, with no output structure")
+
+    atoms = ase.build.molecule('H2O')
+    atoms.center(vacuum=2.0)
+    structure = StructureData(ase=atoms)
+
+    # Construct process builder
+    builder = Cp2kMultistageWorkChain.get_builder()
+    builder.structure = structure
+    builder.protocol_tag = Str('singlepoint')
+    builder.cp2k_base.cp2k.code = cp2k_code
+    builder.cp2k_base.cp2k.metadata.options.resources = {
+        "num_machines": 1,
+        "num_mpiprocs_per_machine": 1,
+    }
+    builder.cp2k_base.cp2k.metadata.options.max_wallclock_seconds = 1 * 3 * 60
+
+    run(builder)
+
+
+@click.command('cli')
+@click.argument('codelabel')
+def cli(codelabel):
+    """Click interface"""
+    try:
+        code = Code.get_from_string(codelabel)
+    except NotExistent:
+        print("The code '{}' does not exist".format(codelabel))
+        sys.exit(1)
+    run_multistage_h2o_singlepoint(code)
+
+
+if __name__ == '__main__':
+    cli()  # pylint: disable=no-value-for-parameter

--- a/examples/run_multistage_h2o_testfile.py
+++ b/examples/run_multistage_h2o_testfile.py
@@ -1,0 +1,56 @@
+""" Test/example for the Cp2kMultistageWorkChain"""
+
+import os
+import sys
+import click
+import ase.build
+
+from aiida.engine import run
+from aiida.orm import Code, StructureData, SinglefileData
+from aiida.common import NotExistent
+from aiida.plugins import WorkflowFactory
+
+Cp2kMultistageWorkChain = WorkflowFactory('lsmo.cp2k_multistage')  # pylint: disable=invalid-name
+
+
+def run_multistage_h2o_testfile(cp2k_code):
+    """Example usage: verdi run thistest.py cp2k@localhost"""
+
+    print("Testing CP2K multistage workchain on H2O")
+    print(">>> Loading a custom protocol from file testfile.yaml")
+
+    atoms = ase.build.molecule('H2O')
+    atoms.center(vacuum=2.0)
+    structure = StructureData(ase=atoms)
+
+    thisdir = os.path.dirname(os.path.abspath(__file__))
+
+    # Construct process builder
+    builder = Cp2kMultistageWorkChain.get_builder()
+    builder.structure = structure
+    builder.protocol_yaml = SinglefileData(
+        file=os.path.abspath(os.path.join(thisdir, '..', 'data', 'test_multistage_protocol.yaml')))
+    builder.cp2k_base.cp2k.code = cp2k_code
+    builder.cp2k_base.cp2k.metadata.options.resources = {
+        "num_machines": 1,
+        "num_mpiprocs_per_machine": 1,
+    }
+    builder.cp2k_base.cp2k.metadata.options.max_wallclock_seconds = 1 * 3 * 60
+
+    run(builder)
+
+
+@click.command('cli')
+@click.argument('codelabel')
+def cli(codelabel):
+    """Click interface"""
+    try:
+        code = Code.get_from_string(codelabel)
+    except NotExistent:
+        print("The code '{}' does not exist".format(codelabel))
+        sys.exit(1)
+    run_multistage_h2o_testfile(code)
+
+
+if __name__ == '__main__':
+    cli()  # pylint: disable=no-value-for-parameter

--- a/examples/run_multistage_h2om.py
+++ b/examples/run_multistage_h2om.py
@@ -1,0 +1,68 @@
+""" Test/example for the Cp2kMultistageWorkChain"""
+
+import sys
+import click
+import ase.build
+
+from aiida.engine import run
+from aiida.orm import Code, Dict, StructureData, Float, Str
+from aiida.common import NotExistent
+from aiida.plugins import WorkflowFactory
+
+Cp2kMultistageWorkChain = WorkflowFactory('lsmo.cp2k_multistage')  # pylint: disable=invalid-name
+
+
+def run_multistage_h2om(cp2k_code):
+    """Example usage: verdi run thistest.py cp2k@localhost"""
+
+    print("Testing CP2K multistage workchain on 2xH2O- (UKS, no need for smearing)...")
+    print("This is checking:")
+    print(" > unit cell resizing")
+    print(" > protocol modification")
+    print(" > cp2k calc modification")
+
+    atoms = ase.build.molecule('H2O')
+    atoms.center(vacuum=2.0)
+    structure = StructureData(ase=atoms)
+
+    protocol_mod = Dict(dict={'settings_0': {'FORCE_EVAL': {'DFT': {'MGRID': {'CUTOFF': 300,}}}}})
+    parameters = Dict(dict={'FORCE_EVAL': {
+        'DFT': {
+            'UKS': True,
+            'MULTIPLICITY': 3,
+            'CHARGE': -2,
+        }
+    }})
+
+    # Construct process builder
+    builder = Cp2kMultistageWorkChain.get_builder()
+    builder.structure = structure
+    builder.min_cell_size = Float(4.1)
+    builder.protocol_tag = Str('test')
+    builder.protocol_modify = protocol_mod
+
+    builder.cp2k_base.cp2k.parameters = parameters
+    builder.cp2k_base.cp2k.code = cp2k_code
+    builder.cp2k_base.cp2k.metadata.options.resources = {
+        "num_machines": 1,
+        "num_mpiprocs_per_machine": 1,
+    }
+    builder.cp2k_base.cp2k.metadata.options.max_wallclock_seconds = 1 * 3 * 60
+
+    run(builder)
+
+
+@click.command('cli')
+@click.argument('codelabel')
+def cli(codelabel):
+    """Click interface"""
+    try:
+        code = Code.get_from_string(codelabel)
+    except NotExistent:
+        print("The code '{}' does not exist".format(codelabel))
+        sys.exit(1)
+    run_multistage_h2om(code)
+
+
+if __name__ == '__main__':
+    cli()  # pylint: disable=no-value-for-parameter

--- a/examples/submit_ZeoppMultistageDdecWorkChain_COF-5.py
+++ b/examples/submit_ZeoppMultistageDdecWorkChain_COF-5.py
@@ -9,7 +9,7 @@ from aiida.plugins import DataFactory, WorkflowFactory
 from aiida.orm import Code, Dict, Str
 
 # Workchain objects
-ZeoppMultistageDdecWorkChain = WorkflowFactory('lsmo.zeoppmultistageddec')  # pylint: disable=invalid-name
+ZeoppMultistageDdecWorkChain = WorkflowFactory('lsmo.zeopp_multistage_ddec')  # pylint: disable=invalid-name
 
 #Data objects
 CifData = DataFactory('cif')  # pylint: disable=invalid-name

--- a/setup.json
+++ b/setup.json
@@ -30,8 +30,8 @@
           "lsmo.calc_selectivity = aiida_lsmo.calcfunctions:calc_selectivity"
         ],
         "aiida.parsers": [
-            "cp2k_bsse_parser = aiida_lsmo.parsers:Cp2kBsseParser",
-            "cp2k_advanced_parser = aiida_lsmo.parsers:Cp2kAdvancedParser"
+            "lsmo.cp2k_bsse_parser = aiida_lsmo.parsers:Cp2kBsseParser",
+            "lsmo.cp2k_advanced_parser = aiida_lsmo.parsers:Cp2kAdvancedParser"
         ],    
         "aiida.workflows": [
             "lsmo.binding_site = aiida_lsmo.workchains:BindingSiteWorkChain",

--- a/setup.json
+++ b/setup.json
@@ -33,14 +33,15 @@
             "cp2k_advanced_parser = aiida_lsmo.parsers:Cp2kAdvancedParser"
         ],    
         "aiida.workflows": [
+            "lsmo.binding_site = aiida_lsmo.workchains:BindingSiteWorkChain",
+            "lsmo.cp2k_binding_energy = aiida_lsmo.workchains.cp2k_binding_energy:Cp2kBindingEnergyWorkChain",
+            "lsmo.cp2k_multistage = aiida_lsmo.workchains:Cp2kMultistageWorkChain",
+            "lsmo.cp2k_multistage_ddec = aiida_lsmo.workchains:Cp2kMultistageDdecWorkChain",
             "lsmo.isotherm = aiida_lsmo.workchains:IsothermWorkChain",
             "lsmo.isotherm_multi_temp = aiida_lsmo.workchains:IsothermMultiTempWorkChain",
             "lsmo.isotherm_calc_pe = aiida_lsmo.workchains:IsothermCalcPEWorkChain",
-            "lsmo.zeoppmultistageddec = aiida_lsmo.workchains:ZeoppMultistageDdecWorkChain",
-            "lsmo.multistageddec = aiida_lsmo.workchains:MultistageDdecWorkChain",
+            "lsmo.zeopp_multistage_ddec = aiida_lsmo.workchains:ZeoppMultistageDdecWorkChain",
             "lsmo.sim_annealing = aiida_lsmo.workchains.sim_annealing:SimAnnealingWorkChain",
-            "lsmo.cp2k_binding_energy = aiida_lsmo.workchains.cp2k_binding_energy:Cp2kBindingEnergyWorkChain",
-            "lsmo.binding_site = aiida_lsmo.workchains:BindingSiteWorkChain",
             "lsmo.nanoporous_screening_1 = aiida_lsmo.workchains:NanoporousScreening1WorkChain"
         ]
     },

--- a/setup.json
+++ b/setup.json
@@ -18,7 +18,8 @@
         "aiida-ddec >= 1.0.0a1",
         "aiida-zeopp >= 1.0.3",
         "aiida-raspa >= 1.0.0a3",
-        "calc-pe >= 1.0.1"
+        "calc-pe >= 1.0.1",
+        "ruamel.yaml>=0.16.5"
     ],
     "entry_points": {
         "aiida.calculations": [

--- a/setup.json
+++ b/setup.json
@@ -14,10 +14,10 @@
     "reentry_register": true,
     "install_requires": [
         "aiida-core >= 1.0.0",
-        "aiida-cp2k >= 1.0.0b4",
+        "aiida-cp2k >= 1.0.0b6",
         "aiida-ddec >= 1.0.0a1",
         "aiida-zeopp >= 1.0.3",
-        "aiida-raspa >= 1.0.0a3",
+        "aiida-raspa >= 1.1.0",
         "calc-pe >= 1.0.1",
         "ruamel.yaml>=0.16.5"
     ],

--- a/setup.json
+++ b/setup.json
@@ -28,6 +28,10 @@
           "lsmo.calc_o2_working_cap = aiida_lsmo.calcfunctions:calc_o2_working_cap",
           "lsmo.calc_selectivity = aiida_lsmo.calcfunctions:calc_selectivity"
         ],
+        "aiida.parsers": [
+            "cp2k_bsse_parser = aiida_lsmo.parsers:Cp2kBsseParser",
+            "cp2k_advanced_parser = aiida_lsmo.parsers:Cp2kAdvancedParser"
+        ],    
         "aiida.workflows": [
             "lsmo.isotherm = aiida_lsmo.workchains:IsothermWorkChain",
             "lsmo.isotherm_multi_temp = aiida_lsmo.workchains:IsothermMultiTempWorkChain",

--- a/tests/outputs/BSSE_output_v5.1_.out
+++ b/tests/outputs/BSSE_output_v5.1_.out
@@ -1,0 +1,7644 @@
+ DBCSR| Multiplication driver                                               BLAS
+ DBCSR| Multrec recursion limit                                              512
+ DBCSR| Multiplication stack size                                           1000
+ DBCSR| Maximum elements for images                                    UNLIMITED
+ DBCSR| Multiplicative factor virtual images                                   1
+ DBCSR| Multiplication size stacks                                             3
+ DBCSR| Number of 3D layers                                               SINGLE
+ DBCSR| Use MPI memory allocation                                              T
+ DBCSR| Use RMA algorithm                                                      F
+ DBCSR| Use Communication thread                                               T
+ DBCSR| Communication thread load                                             87
+
+
+  **** **** ******  **  PROGRAM STARTED AT               2020-01-15 16:09:55.495
+ ***** ** ***  *** **   PROGRAM STARTED ON                         daniele-Ubu18
+ **    ****   ******    PROGRAM STARTED BY                               daniele
+ ***** **    ** ** **   PROGRAM PROCESS ID                                 25190
+  **** **  *******  **  PROGRAM STARTED IN /home/daniele/dev_aiida/aiida_run/42/
+                                           44/db1b-725a-45fb-864b-3c8fb1336084
+
+ CP2K| version string:                                          CP2K version 5.1
+ CP2K| source code revision number:                                    svn:18091
+ CP2K| cp2kflags: libint fftw3 libxc parallel mpi3 scalapack libderiv_max_am1=5 
+ CP2K|            libint_max_am=6
+ CP2K| is freely available from                            https://www.cp2k.org/
+ CP2K| Program compiled at                          Mon Jan 15 17:12:42 UTC 2018
+ CP2K| Program compiled on                                       lgw01-amd64-018
+ CP2K| Program compiled for                                Linux-x86_64-gfortran
+ CP2K| Data directory path         /home/daniele/aiida-lsmo-codes/data/cp2k/data
+ CP2K| Input file name                                                 aiida.inp
+
+ GLOBAL| Force Environment number                                              1
+ GLOBAL| Basis set file name                                        BASIS_MOLOPT
+ GLOBAL| Potential file name                                      GTH_POTENTIALS
+ GLOBAL| MM Potential file name                                     MM_POTENTIAL
+ GLOBAL| Coordinate file name                                   aiida.coords.xyz
+ GLOBAL| Method name                                                        CP2K
+ GLOBAL| Project name                                                      aiida
+ GLOBAL| Preferred FFT library                                             FFTW3
+ GLOBAL| Preferred diagonalization lib.                                       SL
+ GLOBAL| Run type                                                           BSSE
+ GLOBAL| All-to-all communication in single precision                          F
+ GLOBAL| FFTs using library dependent lengths                                  F
+ GLOBAL| Global print level                                               MEDIUM
+ GLOBAL| Total number of message passing processes                             4
+ GLOBAL| Number of threads for this process                                    1
+ GLOBAL| This output is from process                                           0
+ GLOBAL| CPU model name :  Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz
+
+ MEMORY| system memory details [Kb]
+ MEMORY|                        rank 0           min           max       average
+ MEMORY| MemTotal             32843632      32843632      32843632      32843632
+ MEMORY| MemFree               1430164       1430164       1430164       1430164
+ MEMORY| Buffers               1936816       1936816       1936816       1936816
+ MEMORY| Cached               16259028      16259028      16259028      16259028
+ MEMORY| Slab                  5658812       5658812       5658812       5658812
+ MEMORY| SReclaimable          5367044       5367044       5367044       5367044
+ MEMORY| MemLikelyFree        24993052      24993052      24993052      24993052
+
+
+ *** Fundamental physical constants (SI units) ***
+
+ *** Literature: B. J. Mohr and B. N. Taylor,
+ ***             CODATA recommended values of the fundamental physical
+ ***             constants: 2006, Web Version 5.1
+ ***             http://physics.nist.gov/constants
+
+ Speed of light in vacuum [m/s]                             2.99792458000000E+08
+ Magnetic constant or permeability of vacuum [N/A**2]       1.25663706143592E-06
+ Electric constant or permittivity of vacuum [F/m]          8.85418781762039E-12
+ Planck constant (h) [J*s]                                  6.62606896000000E-34
+ Planck constant (h-bar) [J*s]                              1.05457162825177E-34
+ Elementary charge [C]                                      1.60217648700000E-19
+ Electron mass [kg]                                         9.10938215000000E-31
+ Electron g factor [ ]                                     -2.00231930436220E+00
+ Proton mass [kg]                                           1.67262163700000E-27
+ Fine-structure constant                                    7.29735253760000E-03
+ Rydberg constant [1/m]                                     1.09737315685270E+07
+ Avogadro constant [1/mol]                                  6.02214179000000E+23
+ Boltzmann constant [J/K]                                   1.38065040000000E-23
+ Atomic mass unit [kg]                                      1.66053878200000E-27
+ Bohr radius [m]                                            5.29177208590000E-11
+
+ *** Conversion factors ***
+
+ [u] -> [a.u.]                                              1.82288848426455E+03
+ [Angstrom] -> [Bohr] = [a.u.]                              1.88972613288564E+00
+ [a.u.] = [Bohr] -> [Angstrom]                              5.29177208590000E-01
+ [a.u.] -> [s]                                              2.41888432650478E-17
+ [a.u.] -> [fs]                                             2.41888432650478E-02
+ [a.u.] -> [J]                                              4.35974393937059E-18
+ [a.u.] -> [N]                                              8.23872205491840E-08
+ [a.u.] -> [K]                                              3.15774647902944E+05
+ [a.u.] -> [kJ/mol]                                         2.62549961709828E+03
+ [a.u.] -> [kcal/mol]                                       6.27509468713739E+02
+ [a.u.] -> [Pa]                                             2.94210107994716E+13
+ [a.u.] -> [bar]                                            2.94210107994716E+08
+ [a.u.] -> [atm]                                            2.90362800883016E+08
+ [a.u.] -> [eV]                                             2.72113838565563E+01
+ [a.u.] -> [Hz]                                             6.57968392072181E+15
+ [a.u.] -> [1/cm] (wave numbers)                            2.19474631370540E+05
+ [a.u./Bohr**2] -> [1/cm]                                   5.14048714338585E+03
+ 
+
+ CELL_TOP| Volume [angstrom^3]:                                         1375.527
+ CELL_TOP| Vector a [angstrom     6.917     0.000    -1.071    |a| =       6.999
+ CELL_TOP| Vector b [angstrom    -3.459    13.046    -7.086    |b| =      15.244
+ CELL_TOP| Vector c [angstrom     0.000     0.000    15.244    |c| =      15.244
+ CELL_TOP| Angle (b,c), alpha [degree]:                                  117.699
+ CELL_TOP| Angle (a,c), beta  [degree]:                                   98.805
+ CELL_TOP| Angle (a,b), gamma [degree]:                                   98.807
+ CELL_TOP| Numerically orthorhombic:                                          NO
+
+ GENERATE|  Preliminary Number of Bonds generated:                             0
+ GENERATE|  Achieved consistency in connectivity generation.
+
+ CELL| Volume [angstrom^3]:                                             1375.527
+ CELL| Vector a [angstrom]:       6.917     0.000    -1.071    |a| =       6.999
+ CELL| Vector b [angstrom]:      -3.459    13.046    -7.086    |b| =      15.244
+ CELL| Vector c [angstrom]:       0.000     0.000    15.244    |c| =      15.244
+ CELL| Angle (b,c), alpha [degree]:                                      117.699
+ CELL| Angle (a,c), beta  [degree]:                                       98.805
+ CELL| Angle (a,b), gamma [degree]:                                       98.807
+ CELL| Numerically orthorhombic:                                              NO
+
+ CELL_REF| Volume [angstrom^3]:                                         1375.527
+ CELL_REF| Vector a [angstrom     6.917     0.000    -1.071    |a| =       6.999
+ CELL_REF| Vector b [angstrom    -3.459    13.046    -7.086    |b| =      15.244
+ CELL_REF| Vector c [angstrom     0.000     0.000    15.244    |c| =      15.244
+ CELL_REF| Angle (b,c), alpha [degree]:                                  117.699
+ CELL_REF| Angle (a,c), beta  [degree]:                                   98.805
+ CELL_REF| Angle (a,b), gamma [degree]:                                   98.807
+ CELL_REF| Numerically orthorhombic:                                          NO
+
+ *******************************************************************************
+ *******************************************************************************
+ **                                                                           **
+ **     #####                         ##              ##                      **
+ **    ##   ##            ##          ##              ##                      **
+ **   ##     ##                       ##            ######                    **
+ **   ##     ##  ##   ##  ##   #####  ##  ##   ####   ##    #####    #####    **
+ **   ##     ##  ##   ##  ##  ##      ## ##   ##      ##   ##   ##  ##   ##   **
+ **   ##  ## ##  ##   ##  ##  ##      ####     ###    ##   ######   ######    **
+ **    ##  ###   ##   ##  ##  ##      ## ##      ##   ##   ##       ##        **
+ **     #######   #####   ##   #####  ##  ##  ####    ##    #####   ##        **
+ **           ##                                                    ##        **
+ **                                                                           **
+ **                                                ... make the atoms dance   **
+ **                                                                           **
+ **            Copyright (C) by CP2K developers group (2000 - 2017)           **
+ **                                                                           **
+ *******************************************************************************
+
+ DFT| Spin restricted Kohn-Sham (RKS) calculation                            RKS
+ DFT| Multiplicity                                                             1
+ DFT| Number of spin states                                                    1
+ DFT| Charge                                                                   0
+ DFT| Self-interaction correction (SIC)                                       NO
+ DFT| Cutoffs: density                                              1.000000E-10
+ DFT|          gradient                                             1.000000E-10
+ DFT|          tau                                                  1.000000E-10
+ DFT|          cutoff_smoothing_range                               0.000000E+00
+ DFT| XC density smoothing                                                  NONE
+ DFT| XC derivatives                                                          PW
+ FUNCTIONAL| ROUTINE=NEW
+ FUNCTIONAL| PBE:
+ FUNCTIONAL| J.P.Perdew, K.Burke, M.Ernzerhof, Phys. Rev. Letter, vol. 77, n 18,
+ FUNCTIONAL|  pp. 3865-3868, (1996){spin unpolarized}                           
+ vdW POTENTIAL|                                                   Pair Potential
+ vdW POTENTIAL|          DFT-D3 (Version 3.1)
+ vdW POTENTIAL|          Potential Form: S. Grimme et al, JCP 132: 154104 (2010)
+ vdW POTENTIAL|          BJ Damping: S. Grimme et al, JCC 32: 1456 (2011)
+ vdW POTENTIAL|          Cutoff Radius [Bohr]:                             20.00
+ vdW POTENTIAL|          s6 Scaling Factor:                               1.0000
+ vdW POTENTIAL|          a1 Damping Factor:                               0.4289
+ vdW POTENTIAL|          s8 Scaling Factor:                               0.7875
+ vdW POTENTIAL|          a2 Damping Factor:                               4.4407
+ vdW POTENTIAL|          Cutoff for CN calculation:                   0.1000E-05
+
+ QS| Method:                                                                 GPW
+ QS| Density plane wave grid type                        NON-SPHERICAL FULLSPACE
+ QS| Number of grid levels:                                                    4
+ QS| Density cutoff [a.u.]:                                                150.0
+ QS| Multi grid cutoff [a.u.]: 1) grid level                               150.0
+ QS|                           2) grid level                                50.0
+ QS|                           3) grid level                                16.7
+ QS|                           4) grid level                                 5.6
+ QS| Grid level progression factor:                                          3.0
+ QS| Relative density cutoff [a.u.]:                                        15.0
+ QS| Consistent realspace mapping and integration 
+ QS| Interaction thresholds: eps_pgf_orb:                                1.0E-05
+ QS|                         eps_filter_matrix:                          0.0E+00
+ QS|                         eps_core_charge:                            1.0E-12
+ QS|                         eps_rho_gspace:                             1.0E-10
+ QS|                         eps_rho_rspace:                             1.0E-10
+ QS|                         eps_gvg_rspace:                             1.0E-05
+ QS|                         eps_ppl:                                    1.0E-02
+ QS|                         eps_ppnl:                                   1.0E-07
+
+
+ ATOMIC KIND INFORMATION
+
+  1. Atomic kind: Zn                                    Number of atoms:       6
+
+     Orbital Basis Set                                    DZVP-MOLOPT-SR-GTH-q12
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               7
+       Number of primitive Cartesian functions:                                6
+       Number of Cartesian basis functions:                                   30
+       Number of spherical basis functions:                                   25
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                6.400813       0.070678
+                                                         3.167793      -0.182901
+                                                         1.341704       0.275787
+                                                         0.545418       0.070077
+                                                         0.222222      -0.163015
+                                                         0.079830      -0.058340
+
+                          1       2    3s                6.400813       0.159300
+                                                         3.167793      -0.240359
+                                                         1.341704      -0.028572
+                                                         0.545418      -0.590243
+                                                         0.222222       0.705234
+                                                         0.079830      -0.232595
+
+                          1       3    3px               6.400813       0.044197
+                                                         3.167793      -0.065115
+                                                         1.341704       0.233173
+                                                         0.545418      -0.041743
+                                                         0.222222      -0.119659
+                                                         0.079830      -0.031199
+                          1       3    3py               6.400813       0.044197
+                                                         3.167793      -0.065115
+                                                         1.341704       0.233173
+                                                         0.545418      -0.041743
+                                                         0.222222      -0.119659
+                                                         0.079830      -0.031199
+                          1       3    3pz               6.400813       0.044197
+                                                         3.167793      -0.065115
+                                                         1.341704       0.233173
+                                                         0.545418      -0.041743
+                                                         0.222222      -0.119659
+                                                         0.079830      -0.031199
+
+                          1       4    4px               6.400813       0.240176
+                                                         3.167793      -0.408028
+                                                         1.341704      -0.147214
+                                                         0.545418      -0.102288
+                                                         0.222222       0.357755
+                                                         0.079830      -0.080257
+                          1       4    4py               6.400813       0.240176
+                                                         3.167793      -0.408028
+                                                         1.341704      -0.147214
+                                                         0.545418      -0.102288
+                                                         0.222222       0.357755
+                                                         0.079830      -0.080257
+                          1       4    4pz               6.400813       0.240176
+                                                         3.167793      -0.408028
+                                                         1.341704      -0.147214
+                                                         0.545418      -0.102288
+                                                         0.222222       0.357755
+                                                         0.079830      -0.080257
+
+                          1       5    4dx2              6.400813      12.052935
+                                                         3.167793       4.421864
+                                                         1.341704       0.893324
+                                                         0.545418       0.127232
+                                                         0.222222       0.011466
+                                                         0.079830       0.000178
+                          1       5    4dxy              6.400813      20.876296
+                                                         3.167793       7.658893
+                                                         1.341704       1.547283
+                                                         0.545418       0.220373
+                                                         0.222222       0.019859
+                                                         0.079830       0.000308
+                          1       5    4dxz              6.400813      20.876296
+                                                         3.167793       7.658893
+                                                         1.341704       1.547283
+                                                         0.545418       0.220373
+                                                         0.222222       0.019859
+                                                         0.079830       0.000308
+                          1       5    4dy2              6.400813      12.052935
+                                                         3.167793       4.421864
+                                                         1.341704       0.893324
+                                                         0.545418       0.127232
+                                                         0.222222       0.011466
+                                                         0.079830       0.000178
+                          1       5    4dyz              6.400813      20.876296
+                                                         3.167793       7.658893
+                                                         1.341704       1.547283
+                                                         0.545418       0.220373
+                                                         0.222222       0.019859
+                                                         0.079830       0.000308
+                          1       5    4dz2              6.400813      12.052935
+                                                         3.167793       4.421864
+                                                         1.341704       0.893324
+                                                         0.545418       0.127232
+                                                         0.222222       0.011466
+                                                         0.079830       0.000178
+
+                          1       6    5dx2              6.400813      -3.077244
+                                                         3.167793      -1.397438
+                                                         1.341704      -0.501565
+                                                         0.545418       0.120936
+                                                         0.222222       0.032489
+                                                         0.079830       0.013923
+                          1       6    5dxy              6.400813      -5.329943
+                                                         3.167793      -2.420434
+                                                         1.341704      -0.868735
+                                                         0.545418       0.209468
+                                                         0.222222       0.056272
+                                                         0.079830       0.024116
+                          1       6    5dxz              6.400813      -5.329943
+                                                         3.167793      -2.420434
+                                                         1.341704      -0.868735
+                                                         0.545418       0.209468
+                                                         0.222222       0.056272
+                                                         0.079830       0.024116
+                          1       6    5dy2              6.400813      -3.077244
+                                                         3.167793      -1.397438
+                                                         1.341704      -0.501565
+                                                         0.545418       0.120936
+                                                         0.222222       0.032489
+                                                         0.079830       0.013923
+                          1       6    5dyz              6.400813      -5.329943
+                                                         3.167793      -2.420434
+                                                         1.341704      -0.868735
+                                                         0.545418       0.209468
+                                                         0.222222       0.056272
+                                                         0.079830       0.024116
+                          1       6    5dz2              6.400813      -3.077244
+                                                         3.167793      -1.397438
+                                                         1.341704      -0.501565
+                                                         0.545418       0.120936
+                                                         0.222222       0.032489
+                                                         0.079830       0.013923
+
+                          1       7    5fx3              6.400813      -0.041001
+                                                         3.167793       0.016340
+                                                         1.341704       0.068339
+                                                         0.545418       0.147998
+                                                         0.222222       0.008656
+                                                         0.079830       0.003475
+                          1       7    5fx2y             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fx2z             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fxy2             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fxyz             6.400813      -0.158795
+                                                         3.167793       0.063286
+                                                         1.341704       0.264674
+                                                         0.545418       0.573193
+                                                         0.222222       0.033523
+                                                         0.079830       0.013460
+                          1       7    5fxz2             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fy3              6.400813      -0.041001
+                                                         3.167793       0.016340
+                                                         1.341704       0.068339
+                                                         0.545418       0.147998
+                                                         0.222222       0.008656
+                                                         0.079830       0.003475
+                          1       7    5fy2z             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fyz2             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fz3              6.400813      -0.041001
+                                                         3.167793       0.016340
+                                                         1.341704       0.068339
+                                                         0.545418       0.147998
+                                                         0.222222       0.008656
+                                                         0.079830       0.003475
+
+     GTH Potential information for                                   GTH-PBE-q12
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               1.922338
+       Electronic configuration (s p d ...):                           2   0  10
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.510000
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.400316   11.530041   -8.791898    3.145086
+                                   -8.791898   16.465775   -8.120578
+                                    3.145086   -8.120578    6.445509
+                   1    0.543182    2.597195   -0.594263
+                                   -0.594263    0.703141
+                   2    0.250959  -14.466958
+
+  2. Atomic kind: H                                     Number of atoms:       6
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q1
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               3
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                    5
+       Number of spherical basis functions:                                    5
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s               10.068468      -0.133023
+                                                         2.680223      -0.177618
+                                                         0.791502      -0.258419
+                                                         0.239116      -0.107525
+                                                         0.082193      -0.014019
+
+                          1       2    3s               10.068468       0.344673
+                                                         2.680223       1.819821
+                                                         0.791502      -0.999069
+                                                         0.239116       0.017430
+                                                         0.082193       0.082660
+
+                          1       3    3px              10.068468       0.155326
+                                                         2.680223       0.367157
+                                                         0.791502       0.311480
+                                                         0.239116       0.080105
+                                                         0.082193       0.033440
+                          1       3    3py              10.068468       0.155326
+                                                         2.680223       0.367157
+                                                         0.791502       0.311480
+                                                         0.239116       0.080105
+                                                         0.082193       0.033440
+                          1       3    3pz              10.068468       0.155326
+                                                         2.680223       0.367157
+                                                         0.791502       0.311480
+                                                         0.239116       0.080105
+                                                         0.082193       0.033440
+
+     GTH Potential information for                                    GTH-PBE-q1
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:              12.500000
+       Electronic configuration (s p d ...):                                   1
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.200000   -4.178900    0.724463
+
+  3. Atomic kind: C                                     Number of atoms:      25
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q4
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                5.605331       0.322515
+                                                         2.113016       0.213043
+                                                         0.769911      -0.209686
+                                                         0.348157      -0.219794
+                                                         0.128212      -0.022789
+
+                          1       2    3s                5.605331       0.552234
+                                                         2.113016       0.082072
+                                                         0.769911       0.007843
+                                                         0.348157       0.136893
+                                                         0.128212       0.074283
+
+                          1       3    3px               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+                          1       3    3py               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+                          1       3    3pz               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+
+                          1       4    4px               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+                          1       4    4py               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+                          1       4    4pz               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+
+                          1       5    4dx2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+                          1       5    4dxy              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dxz              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dy2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+                          1       5    4dyz              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dz2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+
+     GTH Potential information for                                    GTH-PBE-q4
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               4.364419
+       Electronic configuration (s p d ...):                               2   2
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.338471   -8.803674    1.339211
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.302576    9.622487
+                   1    0.291507
+
+  4. Atomic kind: O                                     Number of atoms:      20
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q6
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s               10.389228       0.396646
+                                                         3.849621       0.208811
+                                                         1.388401      -0.301641
+                                                         0.496955      -0.274061
+                                                         0.162492      -0.033677
+
+                          1       2    3s               10.389228       0.303673
+                                                         3.849621       0.240943
+                                                         1.388401      -0.313066
+                                                         0.496955      -0.043055
+                                                         0.162492       0.213991
+
+                          1       3    3px              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+                          1       3    3py              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+                          1       3    3pz              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+
+                          1       4    4px              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+                          1       4    4py              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+                          1       4    4pz              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+
+                          1       5    4dx2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+                          1       5    4dxy             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dxz             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dy2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+                          1       5    4dyz             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dz2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+
+     GTH Potential information for                                    GTH-PBE-q6
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               8.360253
+       Electronic configuration (s p d ...):                               2   4
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.244554  -16.667215    2.487311
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.220956   18.337458
+                   1    0.211332
+
+
+ MOLECULE KIND INFORMATION
+
+
+ All atoms are their own molecule, skipping detailed information
+
+
+ TOTAL NUMBERS AND MAXIMUM NUMBERS
+
+  Total number of            - Atomic kinds:                                   4
+                             - Atoms:                                         57
+                             - Shell sets:                                    57
+                             - Shells:                                       285
+                             - Primitive Cartesian functions:                291
+                             - Cartesian basis functions:                    840
+                             - Spherical basis functions:                    765
+
+  Maximum angular momentum of- Orbital basis functions:                        3
+                             - Local part of the GTH pseudopotential:          2
+                             - Non-local part of the GTH pseudopotential:      4
+
+
+ MODULE QUICKSTEP:  ATOMIC COORDINATES IN angstrom
+
+  Atom  Kind  Element       X           Y           Z          Z(eff)       Mass
+
+       1     1 Zn  30   -0.383625    4.293611    6.600223     12.00      65.3800
+       2     1 Zn  30    2.159815    5.301947    7.779863     12.00      65.3800
+       3     1 Zn  30    4.480115    3.451223    7.517364     12.00      65.3800
+       4     1 Zn  30    3.841016    8.753170    0.486751     12.00      65.3800
+       5     1 Zn  30    1.297611    7.744704   -0.692817     12.00      65.3800
+       6     1 Zn  30   -1.022759    9.595428   -0.430460     12.00      65.3800
+       7     2 H    1    4.482787    0.326675    6.269586      1.00       1.0079
+       8     2 H    1   -0.512588    6.923320    4.505711      1.00       1.0079
+       9     2 H    1    2.859209    5.797047   11.033385      1.00       1.0079
+      10     2 H    1   -1.025431   12.719976    0.817165      1.00       1.0079
+      11     2 H    1    3.969979    6.123462    2.581264      1.00       1.0079
+      12     2 H    1    0.598147    7.249603   -3.946328      1.00       1.0079
+      13     3 C    6    1.847192    2.234671    7.703263      4.00      12.0107
+      14     3 C    6    0.863924    1.115183    7.649961      4.00      12.0107
+      15     3 C    6    6.377042    1.321703    6.419893      4.00      12.0107
+      16     3 C    6    5.556141    0.189038    6.393652      4.00      12.0107
+      17     3 C    6    3.788779    5.091774    4.998794      4.00      12.0107
+      18     3 C    6    2.703758    5.827445    4.288289      4.00      12.0107
+      19     3 C    6    1.413046    6.046098    4.857577      4.00      12.0107
+      20     3 C    6    0.476664    6.743674    4.086548      4.00      12.0107
+      21     3 C    6   -0.261767    5.720467    9.332098      4.00      12.0107
+      22     3 C    6   -1.050040    6.104414   10.537978      4.00      12.0107
+      23     3 C    6    4.520985    5.679110    9.682078      4.00      12.0107
+      24     3 C    6    3.884975    6.114329   10.849971      4.00      12.0107
+      25     3 C    6    1.610199   10.812110   -0.616593      4.00      12.0107
+      26     3 C    6    2.593398   11.931598   -0.563280      4.00      12.0107
+      27     3 C    6   -2.919721   11.725078    0.666788      4.00      12.0107
+      28     3 C    6   -2.098784   12.857612    0.693100      4.00      12.0107
+      29     3 C    6   -0.331423    7.955138    2.088110      4.00      12.0107
+      30     3 C    6    0.753633    7.219336    2.798686      4.00      12.0107
+      31     3 C    6    2.044379    7.000814    2.229468      4.00      12.0107
+      32     3 C    6    2.980692    6.303237    3.000509      4.00      12.0107
+      33     3 C    6    3.719192    7.326184   -2.244900      4.00      12.0107
+      34     3 C    6    4.507397    6.942237   -3.450922      4.00      12.0107
+      35     3 C    6   -1.063664    7.367410   -2.595245      4.00      12.0107
+      36     3 C    6   -0.427584    6.932191   -3.762996      4.00      12.0107
+      37     4 O    8    1.377982    3.429566    7.648309      6.00      15.9994
+      38     4 O    8    3.094194    1.983664    7.794712      6.00      15.9994
+      39     4 O    8    5.787621    2.541908    6.286912      6.00      15.9994
+      40     4 O    8    3.507212    4.603457    6.153450      6.00      15.9994
+      41     4 O    8    4.938109    4.973837    4.458421      6.00      15.9994
+      42     4 O    8    1.036370    5.627970    6.097393      6.00      15.9994
+      43     4 O    8   -0.860163    5.013497    8.441294      6.00      15.9994
+      44     4 O    8    0.954027    6.089542    9.221463      6.00      15.9994
+      45     4 O    8    3.820924    4.876904    8.833239      6.00      15.9994
+      46     4 O    8    2.079374    9.617084   -0.561405      6.00      15.9994
+      47     4 O    8    0.363162   11.062987   -0.707808      6.00      15.9994
+      48     4 O    8   -2.330264   10.504743    0.799992      6.00      15.9994
+      49     4 O    8   -0.049786    8.443194    0.933596      6.00      15.9994
+      50     4 O    8   -1.480753    8.073075    2.628483      6.00      15.9994
+      51     4 O    8    2.420986    7.418942    0.989510      6.00      15.9994
+      52     4 O    8    4.317519    8.032893   -1.354390      6.00      15.9994
+      53     4 O    8    2.503330    6.957109   -2.134407      6.00      15.9994
+      54     4 O    8   -0.363568    8.169486   -1.746335      6.00      15.9994
+      55     3 C    6    5.922650    0.971024    9.644414      4.00      12.0107
+      56     4 O    8    5.627701    2.095563    9.433385      6.00      15.9994
+      57     4 O    8    2.756503   12.905778    2.804537      6.00      15.9994
+
+
+
+
+ SCF PARAMETERS         Density guess:                                    ATOMIC
+                        --------------------------------------------------------
+                        max_scf:                                              50
+                        max_scf_history:                                       0
+                        max_diis:                                              4
+                        --------------------------------------------------------
+                        eps_scf:                                        1.00E-04
+                        eps_scf_history:                                0.00E+00
+                        eps_diis:                                       1.00E-01
+                        eps_eigval:                                     1.00E-05
+                        --------------------------------------------------------
+                        level_shift [a.u.]:                                 0.00
+                        --------------------------------------------------------
+                        Outer loop SCF in use 
+                        No variables optimised in outer loop
+                        eps_scf                                         1.00E-04
+                        max_scf                                                5
+                        No outer loop optimization
+                        step_size                                       5.00E-01
+
+ PW_GRID| Information for grid number                                          1
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                    150.0
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -37      37                Points:          75
+ PW_GRID|   Bounds   2            -80      79                Points:         160
+ PW_GRID|   Bounds   3            -80      79                Points:         160
+ PW_GRID| Volume element (a.u.^3)  0.4835E-02     Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                           480000.0      480000      480000
+ PW_GRID|   G-Rays                                6400.0        6400        6400
+ PW_GRID|   Real Space Points                   480000.0      486400      460800
+
+ PW_GRID| Information for grid number                                          2
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                     50.0
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -22      22                Points:          45
+ PW_GRID|   Bounds   2            -48      47                Points:          96
+ PW_GRID|   Bounds   3            -48      47                Points:          96
+ PW_GRID| Volume element (a.u.^3)  0.2238E-01     Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                           103680.0      103725      103635
+ PW_GRID|   G-Rays                                2304.0        2305        2303
+ PW_GRID|   Real Space Points                   103680.0      110592      101376
+
+ PW_GRID| Information for grid number                                          3
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                     16.7
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -12      12                Points:          25
+ PW_GRID|   Bounds   2            -27      26                Points:          54
+ PW_GRID|   Bounds   3            -27      26                Points:          54
+ PW_GRID| Volume element (a.u.^3)  0.1273         Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                            18225.0       18225       18225
+ PW_GRID|   G-Rays                                 729.0         729         729
+ PW_GRID|   Real Space Points                    18225.0       20412       17496
+
+ PW_GRID| Information for grid number                                          4
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                      5.6
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1             -7       7                Points:          15
+ PW_GRID|   Bounds   2            -16      15                Points:          32
+ PW_GRID|   Bounds   3            -16      15                Points:          32
+ PW_GRID| Volume element (a.u.^3)  0.6043         Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                             3840.0        3855        3825
+ PW_GRID|   G-Rays                                 256.0         257         255
+ PW_GRID|   Real Space Points                     3840.0        4096        3072
+
+ POISSON| Solver                                                        PERIODIC
+ POISSON| Periodicity                                                        XYZ
+
+ RS_GRID| Information for grid number                                          1
+ RS_GRID|   Bounds   1            -37      37                Points:          75
+ RS_GRID|   Bounds   2            -80      79                Points:         160
+ RS_GRID|   Bounds   3            -80      79                Points:         160
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                          2
+ RS_GRID|   Bounds   1            -22      22                Points:          45
+ RS_GRID|   Bounds   2            -48      47                Points:          96
+ RS_GRID|   Bounds   3            -48      47                Points:          96
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                          3
+ RS_GRID|   Bounds   1            -12      12                Points:          25
+ RS_GRID|   Bounds   2            -27      26                Points:          54
+ RS_GRID|   Bounds   3            -27      26                Points:          54
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                          4
+ RS_GRID|   Bounds   1             -7       7                Points:          15
+ RS_GRID|   Bounds   2            -16      15                Points:          32
+ RS_GRID|   Bounds   3            -16      15                Points:          32
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ DISTRIBUTION OF THE PARTICLES (ROWS)
+              Process row      Number of particles         Number of matrix rows
+                        0                       29                            -1
+                        1                       28                            -1
+                      Sum                       57                            -1
+
+ DISTRIBUTION OF THE PARTICLES (COLUMNS)
+              Process col      Number of particles      Number of matrix columns
+                        0                       29                            -1
+                        1                       28                            -1
+                      Sum                       57                            -1
+
+ -------------------------------------------------------------------------------
+ -                                                                             -
+ -  BSSE CALCULATION         FRAGMENT CONF: 10        FRAGMENT SUBCONF: 10     -
+ -                           CHARGE =     0           MULTIPLICITY =     1     -
+ -                                                                             -
+ -                 ATOM INDEX                              ATOM NAME           -
+ -                 ----------                              ---------           -
+ -                      1                                   Zn                 -
+ -                      2                                   Zn                 -
+ -                      3                                   Zn                 -
+ -                      4                                   Zn                 -
+ -                      5                                   Zn                 -
+ -                      6                                   Zn                 -
+ -                      7                                   H                  -
+ -                      8                                   H                  -
+ -                      9                                   H                  -
+ -                     10                                   H                  -
+ -                     11                                   H                  -
+ -                     12                                   H                  -
+ -                     13                                   C                  -
+ -                     14                                   C                  -
+ -                     15                                   C                  -
+ -                     16                                   C                  -
+ -                     17                                   C                  -
+ -                     18                                   C                  -
+ -                     19                                   C                  -
+ -                     20                                   C                  -
+ -                     21                                   C                  -
+ -                     22                                   C                  -
+ -                     23                                   C                  -
+ -                     24                                   C                  -
+ -                     25                                   C                  -
+ -                     26                                   C                  -
+ -                     27                                   C                  -
+ -                     28                                   C                  -
+ -                     29                                   C                  -
+ -                     30                                   C                  -
+ -                     31                                   C                  -
+ -                     32                                   C                  -
+ -                     33                                   C                  -
+ -                     34                                   C                  -
+ -                     35                                   C                  -
+ -                     36                                   C                  -
+ -                     37                                   O                  -
+ -                     38                                   O                  -
+ -                     39                                   O                  -
+ -                     40                                   O                  -
+ -                     41                                   O                  -
+ -                     42                                   O                  -
+ -                     43                                   O                  -
+ -                     44                                   O                  -
+ -                     45                                   O                  -
+ -                     46                                   O                  -
+ -                     47                                   O                  -
+ -                     48                                   O                  -
+ -                     49                                   O                  -
+ -                     50                                   O                  -
+ -                     51                                   O                  -
+ -                     52                                   O                  -
+ -                     53                                   O                  -
+ -                     54                                   O                  -
+ -------------------------------------------------------------------------------
+
+ CELL| Volume [angstrom^3]:                                             1375.527
+ CELL| Vector a [angstrom]:       6.917     0.000    -1.071    |a| =       6.999
+ CELL| Vector b [angstrom]:      -3.459    13.046    -7.086    |b| =      15.244
+ CELL| Vector c [angstrom]:       0.000     0.000    15.244    |c| =      15.244
+ CELL| Angle (b,c), alpha [degree]:                                      117.699
+ CELL| Angle (a,c), beta  [degree]:                                       98.805
+ CELL| Angle (a,b), gamma [degree]:                                       98.807
+ CELL| Numerically orthorhombic:                                              NO
+
+ CELL_REF| Volume [angstrom^3]:                                         1375.527
+ CELL_REF| Vector a [angstrom     6.917     0.000    -1.071    |a| =       6.999
+ CELL_REF| Vector b [angstrom    -3.459    13.046    -7.086    |b| =      15.244
+ CELL_REF| Vector c [angstrom     0.000     0.000    15.244    |c| =      15.244
+ CELL_REF| Angle (b,c), alpha [degree]:                                  117.699
+ CELL_REF| Angle (a,c), beta  [degree]:                                   98.805
+ CELL_REF| Angle (a,b), gamma [degree]:                                   98.807
+ CELL_REF| Numerically orthorhombic:                                          NO
+
+ *******************************************************************************
+ *******************************************************************************
+ **                                                                           **
+ **     #####                         ##              ##                      **
+ **    ##   ##            ##          ##              ##                      **
+ **   ##     ##                       ##            ######                    **
+ **   ##     ##  ##   ##  ##   #####  ##  ##   ####   ##    #####    #####    **
+ **   ##     ##  ##   ##  ##  ##      ## ##   ##      ##   ##   ##  ##   ##   **
+ **   ##  ## ##  ##   ##  ##  ##      ####     ###    ##   ######   ######    **
+ **    ##  ###   ##   ##  ##  ##      ## ##      ##   ##   ##       ##        **
+ **     #######   #####   ##   #####  ##  ##  ####    ##    #####   ##        **
+ **           ##                                                    ##        **
+ **                                                                           **
+ **                                                ... make the atoms dance   **
+ **                                                                           **
+ **            Copyright (C) by CP2K developers group (2000 - 2017)           **
+ **                                                                           **
+ *******************************************************************************
+
+ DFT| Spin restricted Kohn-Sham (RKS) calculation                            RKS
+ DFT| Multiplicity                                                             1
+ DFT| Number of spin states                                                    1
+ DFT| Charge                                                                   0
+ DFT| Self-interaction correction (SIC)                                       NO
+ DFT| Cutoffs: density                                              1.000000E-10
+ DFT|          gradient                                             1.000000E-10
+ DFT|          tau                                                  1.000000E-10
+ DFT|          cutoff_smoothing_range                               0.000000E+00
+ DFT| XC density smoothing                                                  NONE
+ DFT| XC derivatives                                                          PW
+ FUNCTIONAL| ROUTINE=NEW
+ FUNCTIONAL| PBE:
+ FUNCTIONAL| J.P.Perdew, K.Burke, M.Ernzerhof, Phys. Rev. Letter, vol. 77, n 18,
+ FUNCTIONAL|  pp. 3865-3868, (1996){spin unpolarized}                           
+ vdW POTENTIAL|                                                   Pair Potential
+ vdW POTENTIAL|          DFT-D3 (Version 3.1)
+ vdW POTENTIAL|          Potential Form: S. Grimme et al, JCP 132: 154104 (2010)
+ vdW POTENTIAL|          BJ Damping: S. Grimme et al, JCC 32: 1456 (2011)
+ vdW POTENTIAL|          Cutoff Radius [Bohr]:                             20.00
+ vdW POTENTIAL|          s6 Scaling Factor:                               1.0000
+ vdW POTENTIAL|          a1 Damping Factor:                               0.4289
+ vdW POTENTIAL|          s8 Scaling Factor:                               0.7875
+ vdW POTENTIAL|          a2 Damping Factor:                               4.4407
+ vdW POTENTIAL|          Cutoff for CN calculation:                   0.1000E-05
+
+ QS| Method:                                                                 GPW
+ QS| Density plane wave grid type                        NON-SPHERICAL FULLSPACE
+ QS| Number of grid levels:                                                    4
+ QS| Density cutoff [a.u.]:                                                150.0
+ QS| Multi grid cutoff [a.u.]: 1) grid level                               150.0
+ QS|                           2) grid level                                50.0
+ QS|                           3) grid level                                16.7
+ QS|                           4) grid level                                 5.6
+ QS| Grid level progression factor:                                          3.0
+ QS| Relative density cutoff [a.u.]:                                        15.0
+ QS| Consistent realspace mapping and integration 
+ QS| Interaction thresholds: eps_pgf_orb:                                1.0E-05
+ QS|                         eps_filter_matrix:                          0.0E+00
+ QS|                         eps_core_charge:                            1.0E-12
+ QS|                         eps_rho_gspace:                             1.0E-10
+ QS|                         eps_rho_rspace:                             1.0E-10
+ QS|                         eps_gvg_rspace:                             1.0E-05
+ QS|                         eps_ppl:                                    1.0E-02
+ QS|                         eps_ppnl:                                   1.0E-07
+
+
+ ATOMIC KIND INFORMATION
+
+  1. Atomic kind: Zn                                    Number of atoms:       6
+
+     Orbital Basis Set                                    DZVP-MOLOPT-SR-GTH-q12
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               7
+       Number of primitive Cartesian functions:                                6
+       Number of Cartesian basis functions:                                   30
+       Number of spherical basis functions:                                   25
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                6.400813       0.070678
+                                                         3.167793      -0.182901
+                                                         1.341704       0.275787
+                                                         0.545418       0.070077
+                                                         0.222222      -0.163015
+                                                         0.079830      -0.058340
+
+                          1       2    3s                6.400813       0.159300
+                                                         3.167793      -0.240359
+                                                         1.341704      -0.028572
+                                                         0.545418      -0.590243
+                                                         0.222222       0.705234
+                                                         0.079830      -0.232595
+
+                          1       3    3px               6.400813       0.044197
+                                                         3.167793      -0.065115
+                                                         1.341704       0.233173
+                                                         0.545418      -0.041743
+                                                         0.222222      -0.119659
+                                                         0.079830      -0.031199
+                          1       3    3py               6.400813       0.044197
+                                                         3.167793      -0.065115
+                                                         1.341704       0.233173
+                                                         0.545418      -0.041743
+                                                         0.222222      -0.119659
+                                                         0.079830      -0.031199
+                          1       3    3pz               6.400813       0.044197
+                                                         3.167793      -0.065115
+                                                         1.341704       0.233173
+                                                         0.545418      -0.041743
+                                                         0.222222      -0.119659
+                                                         0.079830      -0.031199
+
+                          1       4    4px               6.400813       0.240176
+                                                         3.167793      -0.408028
+                                                         1.341704      -0.147214
+                                                         0.545418      -0.102288
+                                                         0.222222       0.357755
+                                                         0.079830      -0.080257
+                          1       4    4py               6.400813       0.240176
+                                                         3.167793      -0.408028
+                                                         1.341704      -0.147214
+                                                         0.545418      -0.102288
+                                                         0.222222       0.357755
+                                                         0.079830      -0.080257
+                          1       4    4pz               6.400813       0.240176
+                                                         3.167793      -0.408028
+                                                         1.341704      -0.147214
+                                                         0.545418      -0.102288
+                                                         0.222222       0.357755
+                                                         0.079830      -0.080257
+
+                          1       5    4dx2              6.400813      12.052935
+                                                         3.167793       4.421864
+                                                         1.341704       0.893324
+                                                         0.545418       0.127232
+                                                         0.222222       0.011466
+                                                         0.079830       0.000178
+                          1       5    4dxy              6.400813      20.876296
+                                                         3.167793       7.658893
+                                                         1.341704       1.547283
+                                                         0.545418       0.220373
+                                                         0.222222       0.019859
+                                                         0.079830       0.000308
+                          1       5    4dxz              6.400813      20.876296
+                                                         3.167793       7.658893
+                                                         1.341704       1.547283
+                                                         0.545418       0.220373
+                                                         0.222222       0.019859
+                                                         0.079830       0.000308
+                          1       5    4dy2              6.400813      12.052935
+                                                         3.167793       4.421864
+                                                         1.341704       0.893324
+                                                         0.545418       0.127232
+                                                         0.222222       0.011466
+                                                         0.079830       0.000178
+                          1       5    4dyz              6.400813      20.876296
+                                                         3.167793       7.658893
+                                                         1.341704       1.547283
+                                                         0.545418       0.220373
+                                                         0.222222       0.019859
+                                                         0.079830       0.000308
+                          1       5    4dz2              6.400813      12.052935
+                                                         3.167793       4.421864
+                                                         1.341704       0.893324
+                                                         0.545418       0.127232
+                                                         0.222222       0.011466
+                                                         0.079830       0.000178
+
+                          1       6    5dx2              6.400813      -3.077244
+                                                         3.167793      -1.397438
+                                                         1.341704      -0.501565
+                                                         0.545418       0.120936
+                                                         0.222222       0.032489
+                                                         0.079830       0.013923
+                          1       6    5dxy              6.400813      -5.329943
+                                                         3.167793      -2.420434
+                                                         1.341704      -0.868735
+                                                         0.545418       0.209468
+                                                         0.222222       0.056272
+                                                         0.079830       0.024116
+                          1       6    5dxz              6.400813      -5.329943
+                                                         3.167793      -2.420434
+                                                         1.341704      -0.868735
+                                                         0.545418       0.209468
+                                                         0.222222       0.056272
+                                                         0.079830       0.024116
+                          1       6    5dy2              6.400813      -3.077244
+                                                         3.167793      -1.397438
+                                                         1.341704      -0.501565
+                                                         0.545418       0.120936
+                                                         0.222222       0.032489
+                                                         0.079830       0.013923
+                          1       6    5dyz              6.400813      -5.329943
+                                                         3.167793      -2.420434
+                                                         1.341704      -0.868735
+                                                         0.545418       0.209468
+                                                         0.222222       0.056272
+                                                         0.079830       0.024116
+                          1       6    5dz2              6.400813      -3.077244
+                                                         3.167793      -1.397438
+                                                         1.341704      -0.501565
+                                                         0.545418       0.120936
+                                                         0.222222       0.032489
+                                                         0.079830       0.013923
+
+                          1       7    5fx3              6.400813      -0.041001
+                                                         3.167793       0.016340
+                                                         1.341704       0.068339
+                                                         0.545418       0.147998
+                                                         0.222222       0.008656
+                                                         0.079830       0.003475
+                          1       7    5fx2y             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fx2z             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fxy2             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fxyz             6.400813      -0.158795
+                                                         3.167793       0.063286
+                                                         1.341704       0.264674
+                                                         0.545418       0.573193
+                                                         0.222222       0.033523
+                                                         0.079830       0.013460
+                          1       7    5fxz2             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fy3              6.400813      -0.041001
+                                                         3.167793       0.016340
+                                                         1.341704       0.068339
+                                                         0.545418       0.147998
+                                                         0.222222       0.008656
+                                                         0.079830       0.003475
+                          1       7    5fy2z             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fyz2             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fz3              6.400813      -0.041001
+                                                         3.167793       0.016340
+                                                         1.341704       0.068339
+                                                         0.545418       0.147998
+                                                         0.222222       0.008656
+                                                         0.079830       0.003475
+
+     GTH Potential information for                                   GTH-PBE-q12
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               1.922338
+       Electronic configuration (s p d ...):                           2   0  10
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.510000
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.400316   11.530041   -8.791898    3.145086
+                                   -8.791898   16.465775   -8.120578
+                                    3.145086   -8.120578    6.445509
+                   1    0.543182    2.597195   -0.594263
+                                   -0.594263    0.703141
+                   2    0.250959  -14.466958
+
+  2. Atomic kind: H                                     Number of atoms:       6
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q1
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               3
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                    5
+       Number of spherical basis functions:                                    5
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s               10.068468      -0.133023
+                                                         2.680223      -0.177618
+                                                         0.791502      -0.258419
+                                                         0.239116      -0.107525
+                                                         0.082193      -0.014019
+
+                          1       2    3s               10.068468       0.344673
+                                                         2.680223       1.819821
+                                                         0.791502      -0.999069
+                                                         0.239116       0.017430
+                                                         0.082193       0.082660
+
+                          1       3    3px              10.068468       0.155326
+                                                         2.680223       0.367157
+                                                         0.791502       0.311480
+                                                         0.239116       0.080105
+                                                         0.082193       0.033440
+                          1       3    3py              10.068468       0.155326
+                                                         2.680223       0.367157
+                                                         0.791502       0.311480
+                                                         0.239116       0.080105
+                                                         0.082193       0.033440
+                          1       3    3pz              10.068468       0.155326
+                                                         2.680223       0.367157
+                                                         0.791502       0.311480
+                                                         0.239116       0.080105
+                                                         0.082193       0.033440
+
+     GTH Potential information for                                    GTH-PBE-q1
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:              12.500000
+       Electronic configuration (s p d ...):                                   1
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.200000   -4.178900    0.724463
+
+  3. Atomic kind: C                                     Number of atoms:      24
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q4
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                5.605331       0.322515
+                                                         2.113016       0.213043
+                                                         0.769911      -0.209686
+                                                         0.348157      -0.219794
+                                                         0.128212      -0.022789
+
+                          1       2    3s                5.605331       0.552234
+                                                         2.113016       0.082072
+                                                         0.769911       0.007843
+                                                         0.348157       0.136893
+                                                         0.128212       0.074283
+
+                          1       3    3px               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+                          1       3    3py               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+                          1       3    3pz               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+
+                          1       4    4px               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+                          1       4    4py               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+                          1       4    4pz               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+
+                          1       5    4dx2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+                          1       5    4dxy              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dxz              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dy2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+                          1       5    4dyz              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dz2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+
+     GTH Potential information for                                    GTH-PBE-q4
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               4.364419
+       Electronic configuration (s p d ...):                               2   2
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.338471   -8.803674    1.339211
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.302576    9.622487
+                   1    0.291507
+
+  4. Atomic kind: O                                     Number of atoms:      18
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q6
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s               10.389228       0.396646
+                                                         3.849621       0.208811
+                                                         1.388401      -0.301641
+                                                         0.496955      -0.274061
+                                                         0.162492      -0.033677
+
+                          1       2    3s               10.389228       0.303673
+                                                         3.849621       0.240943
+                                                         1.388401      -0.313066
+                                                         0.496955      -0.043055
+                                                         0.162492       0.213991
+
+                          1       3    3px              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+                          1       3    3py              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+                          1       3    3pz              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+
+                          1       4    4px              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+                          1       4    4py              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+                          1       4    4pz              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+
+                          1       5    4dx2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+                          1       5    4dxy             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dxz             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dy2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+                          1       5    4dyz             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dz2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+
+     GTH Potential information for                                    GTH-PBE-q6
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               8.360253
+       Electronic configuration (s p d ...):                               2   4
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.244554  -16.667215    2.487311
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.220956   18.337458
+                   1    0.211332
+
+
+ MOLECULE KIND INFORMATION
+
+
+ All atoms are their own molecule, skipping detailed information
+
+
+ TOTAL NUMBERS AND MAXIMUM NUMBERS
+
+  Total number of            - Atomic kinds:                                   4
+                             - Atoms:                                         54
+                             - Shell sets:                                    54
+                             - Shells:                                       270
+                             - Primitive Cartesian functions:                276
+                             - Cartesian basis functions:                    798
+                             - Spherical basis functions:                    726
+
+  Maximum angular momentum of- Orbital basis functions:                        3
+                             - Local part of the GTH pseudopotential:          2
+                             - Non-local part of the GTH pseudopotential:      4
+
+
+ MODULE QUICKSTEP:  ATOMIC COORDINATES IN angstrom
+
+  Atom  Kind  Element       X           Y           Z          Z(eff)       Mass
+
+       1     1 Zn  30   -0.383625    4.293611    6.600223     12.00      65.3800
+       2     1 Zn  30    2.159815    5.301947    7.779863     12.00      65.3800
+       3     1 Zn  30    4.480115    3.451223    7.517364     12.00      65.3800
+       4     1 Zn  30    3.841016    8.753170    0.486751     12.00      65.3800
+       5     1 Zn  30    1.297611    7.744704   -0.692817     12.00      65.3800
+       6     1 Zn  30   -1.022759    9.595428   -0.430460     12.00      65.3800
+       7     2 H    1    4.482787    0.326675    6.269586      1.00       1.0079
+       8     2 H    1   -0.512588    6.923320    4.505711      1.00       1.0079
+       9     2 H    1    2.859209    5.797047   11.033385      1.00       1.0079
+      10     2 H    1   -1.025431   12.719976    0.817165      1.00       1.0079
+      11     2 H    1    3.969979    6.123462    2.581264      1.00       1.0079
+      12     2 H    1    0.598147    7.249603   -3.946328      1.00       1.0079
+      13     3 C    6    1.847192    2.234671    7.703263      4.00      12.0107
+      14     3 C    6    0.863924    1.115183    7.649961      4.00      12.0107
+      15     3 C    6    6.377042    1.321703    6.419893      4.00      12.0107
+      16     3 C    6    5.556141    0.189038    6.393652      4.00      12.0107
+      17     3 C    6    3.788779    5.091774    4.998794      4.00      12.0107
+      18     3 C    6    2.703758    5.827445    4.288289      4.00      12.0107
+      19     3 C    6    1.413046    6.046098    4.857577      4.00      12.0107
+      20     3 C    6    0.476664    6.743674    4.086548      4.00      12.0107
+      21     3 C    6   -0.261767    5.720467    9.332098      4.00      12.0107
+      22     3 C    6   -1.050040    6.104414   10.537978      4.00      12.0107
+      23     3 C    6    4.520985    5.679110    9.682078      4.00      12.0107
+      24     3 C    6    3.884975    6.114329   10.849971      4.00      12.0107
+      25     3 C    6    1.610199   10.812110   -0.616593      4.00      12.0107
+      26     3 C    6    2.593398   11.931598   -0.563280      4.00      12.0107
+      27     3 C    6   -2.919721   11.725078    0.666788      4.00      12.0107
+      28     3 C    6   -2.098784   12.857612    0.693100      4.00      12.0107
+      29     3 C    6   -0.331423    7.955138    2.088110      4.00      12.0107
+      30     3 C    6    0.753633    7.219336    2.798686      4.00      12.0107
+      31     3 C    6    2.044379    7.000814    2.229468      4.00      12.0107
+      32     3 C    6    2.980692    6.303237    3.000509      4.00      12.0107
+      33     3 C    6    3.719192    7.326184   -2.244900      4.00      12.0107
+      34     3 C    6    4.507397    6.942237   -3.450922      4.00      12.0107
+      35     3 C    6   -1.063664    7.367410   -2.595245      4.00      12.0107
+      36     3 C    6   -0.427584    6.932191   -3.762996      4.00      12.0107
+      37     4 O    8    1.377982    3.429566    7.648309      6.00      15.9994
+      38     4 O    8    3.094194    1.983664    7.794712      6.00      15.9994
+      39     4 O    8    5.787621    2.541908    6.286912      6.00      15.9994
+      40     4 O    8    3.507212    4.603457    6.153450      6.00      15.9994
+      41     4 O    8    4.938109    4.973837    4.458421      6.00      15.9994
+      42     4 O    8    1.036370    5.627970    6.097393      6.00      15.9994
+      43     4 O    8   -0.860163    5.013497    8.441294      6.00      15.9994
+      44     4 O    8    0.954027    6.089542    9.221463      6.00      15.9994
+      45     4 O    8    3.820924    4.876904    8.833239      6.00      15.9994
+      46     4 O    8    2.079374    9.617084   -0.561405      6.00      15.9994
+      47     4 O    8    0.363162   11.062987   -0.707808      6.00      15.9994
+      48     4 O    8   -2.330264   10.504743    0.799992      6.00      15.9994
+      49     4 O    8   -0.049786    8.443194    0.933596      6.00      15.9994
+      50     4 O    8   -1.480753    8.073075    2.628483      6.00      15.9994
+      51     4 O    8    2.420986    7.418942    0.989510      6.00      15.9994
+      52     4 O    8    4.317519    8.032893   -1.354390      6.00      15.9994
+      53     4 O    8    2.503330    6.957109   -2.134407      6.00      15.9994
+      54     4 O    8   -0.363568    8.169486   -1.746335      6.00      15.9994
+
+
+
+
+ SCF PARAMETERS         Density guess:                                    ATOMIC
+                        --------------------------------------------------------
+                        max_scf:                                              50
+                        max_scf_history:                                       0
+                        max_diis:                                              4
+                        --------------------------------------------------------
+                        eps_scf:                                        1.00E-04
+                        eps_scf_history:                                0.00E+00
+                        eps_diis:                                       1.00E-01
+                        eps_eigval:                                     1.00E-05
+                        --------------------------------------------------------
+                        level_shift [a.u.]:                                 0.00
+                        --------------------------------------------------------
+                        Outer loop SCF in use 
+                        No variables optimised in outer loop
+                        eps_scf                                         1.00E-04
+                        max_scf                                                5
+                        No outer loop optimization
+                        step_size                                       5.00E-01
+
+ PW_GRID| Information for grid number                                          5
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                    150.0
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -37      37                Points:          75
+ PW_GRID|   Bounds   2            -80      79                Points:         160
+ PW_GRID|   Bounds   3            -80      79                Points:         160
+ PW_GRID| Volume element (a.u.^3)  0.4835E-02     Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                           480000.0      480000      480000
+ PW_GRID|   G-Rays                                6400.0        6400        6400
+ PW_GRID|   Real Space Points                   480000.0      486400      460800
+
+ PW_GRID| Information for grid number                                          6
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                     50.0
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -22      22                Points:          45
+ PW_GRID|   Bounds   2            -48      47                Points:          96
+ PW_GRID|   Bounds   3            -48      47                Points:          96
+ PW_GRID| Volume element (a.u.^3)  0.2238E-01     Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                           103680.0      103725      103635
+ PW_GRID|   G-Rays                                2304.0        2305        2303
+ PW_GRID|   Real Space Points                   103680.0      110592      101376
+
+ PW_GRID| Information for grid number                                          7
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                     16.7
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -12      12                Points:          25
+ PW_GRID|   Bounds   2            -27      26                Points:          54
+ PW_GRID|   Bounds   3            -27      26                Points:          54
+ PW_GRID| Volume element (a.u.^3)  0.1273         Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                            18225.0       18225       18225
+ PW_GRID|   G-Rays                                 729.0         729         729
+ PW_GRID|   Real Space Points                    18225.0       20412       17496
+
+ PW_GRID| Information for grid number                                          8
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                      5.6
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1             -7       7                Points:          15
+ PW_GRID|   Bounds   2            -16      15                Points:          32
+ PW_GRID|   Bounds   3            -16      15                Points:          32
+ PW_GRID| Volume element (a.u.^3)  0.6043         Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                             3840.0        3855        3825
+ PW_GRID|   G-Rays                                 256.0         257         255
+ PW_GRID|   Real Space Points                     3840.0        4096        3072
+
+ POISSON| Solver                                                        PERIODIC
+ POISSON| Periodicity                                                        XYZ
+
+ RS_GRID| Information for grid number                                          5
+ RS_GRID|   Bounds   1            -37      37                Points:          75
+ RS_GRID|   Bounds   2            -80      79                Points:         160
+ RS_GRID|   Bounds   3            -80      79                Points:         160
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                          6
+ RS_GRID|   Bounds   1            -22      22                Points:          45
+ RS_GRID|   Bounds   2            -48      47                Points:          96
+ RS_GRID|   Bounds   3            -48      47                Points:          96
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                          7
+ RS_GRID|   Bounds   1            -12      12                Points:          25
+ RS_GRID|   Bounds   2            -27      26                Points:          54
+ RS_GRID|   Bounds   3            -27      26                Points:          54
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                          8
+ RS_GRID|   Bounds   1             -7       7                Points:          15
+ RS_GRID|   Bounds   2            -16      15                Points:          32
+ RS_GRID|   Bounds   3            -16      15                Points:          32
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ DISTRIBUTION OF THE PARTICLES (ROWS)
+              Process row      Number of particles         Number of matrix rows
+                        0                       27                            -1
+                        1                       27                            -1
+                      Sum                       54                            -1
+
+ DISTRIBUTION OF THE PARTICLES (COLUMNS)
+              Process col      Number of particles      Number of matrix columns
+                        0                       27                            -1
+                        1                       27                            -1
+                      Sum                       54                            -1
+
+ DISTRIBUTION OF THE NEIGHBOR LISTS
+              Total number of particle pairs:                               5634
+              Total number of matrix elements:                           1114410
+              Average number of particle pairs:                             1409
+              Maximum number of particle pairs:                             1432
+              Average number of matrix element:                           278603
+              Maximum number of matrix elements:                          282932
+
+
+ DISTRIBUTION OF THE OVERLAP MATRIX
+              Number  of non-zero blocks:                                   1485
+              Percentage non-zero blocks:                                 100.00
+              Average number of blocks per CPU:                              372
+              Maximum number of blocks per CPU:                              378
+              Average number of matrix elements per CPU:                   67270
+              Maximum number of matrix elements per CPU:                   68644
+
+ Number of electrons:                                                        282
+ Number of occupied orbitals:                                                141
+ Number of molecular orbitals:                                               141
+
+ Number of orbital functions:                                                726
+ Number of independent orbital functions:                                    726
+
+ Extrapolation method: initial_guess
+
+ Atomic guess: The first density matrix is obtained in terms of atomic orbitals
+               and electronic configurations assigned to each atomic kind
+
+ Guess for atomic kind: Zn
+
+ Electronic structure
+    Total number of core electrons                                         18.00
+    Total number of valence electrons                                      12.00
+    Total number of electrons                                              30.00
+    Multiplicity                                                   not specified
+    S   [  2.00  2.00  2.00] 2.00
+    P   [  6.00  6.00]
+    D     10.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1         1.62924                     -59.451394251983
+                          2         9.44946                     -57.380718340026
+                          3         1.20534                     -60.073283596570
+                          4        0.228441                     -60.149512613300
+                          5        0.659017E-01                 -60.153075514012
+                          6        0.364244E-01                 -60.153290281981
+                          7        0.826658E-01                 -60.152916515694
+                          8        0.577629E-03                 -60.153383695723
+                          9        0.361798E-03                 -60.153383709870
+                         10        0.208007E-03                 -60.153383715984
+                         11        0.873205E-04                 -60.153383718472
+                         12        0.217219E-05                 -60.153383719003
+                         13        0.826432E-08                 -60.153383719004
+
+ Energy components [Hartree]           Total Energy ::          -60.153383719004
+                                        Band Energy ::           -3.832693908022
+                                     Kinetic Energy ::           84.396829637188
+                                   Potential Energy ::         -144.550213356191
+                                      Virial (-V/T) ::            1.712744589786
+                                        Core Energy ::         -110.535288508001
+                                          XC Energy ::           -8.666206286402
+                                     Coulomb Energy ::           59.048111075399
+                       Total Pseudopotential Energy ::         -195.030087576096
+                       Local Pseudopotential Energy ::         -135.966032502182
+                    Nonlocal Pseudopotential Energy ::          -59.064055073914
+                                        Confinement ::            0.979694309070
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.191113           -5.200458
+
+                       1     2         10.000      -0.345047           -9.389199
+
+
+ Total Electron Density at R=0:                                         0.000033
+
+ Guess for atomic kind: H
+
+ Electronic structure
+    Total number of core electrons                                          0.00
+    Total number of valence electrons                                       1.00
+    Total number of electrons                                               1.00
+    Multiplicity                                                   not specified
+    S      1.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1        0.250972E-02                  -0.375256815885
+                          2        0.570752E-04                  -0.375258666164
+                          3        0.832405E-09                  -0.375258667122
+
+ Energy components [Hartree]           Total Energy ::           -0.375258667122
+                                        Band Energy ::           -0.076317618391
+                                     Kinetic Energy ::            0.771356566341
+                                   Potential Energy ::           -1.146615233463
+                                      Virial (-V/T) ::            1.486491829455
+                                        Core Energy ::           -0.456090715790
+                                          XC Energy ::           -0.314218627334
+                                     Coulomb Energy ::            0.395050676003
+                       Total Pseudopotential Energy ::           -1.238482237174
+                       Local Pseudopotential Energy ::           -1.238482237174
+                    Nonlocal Pseudopotential Energy ::            0.000000000000
+                                        Confinement ::            0.110349550431
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          1.000      -0.076318           -2.076708
+
+
+ Total Electron Density at R=0:                                         0.425022
+
+ Guess for atomic kind: C
+
+ Electronic structure
+    Total number of core electrons                                          2.00
+    Total number of valence electrons                                       4.00
+    Total number of electrons                                               6.00
+    Multiplicity                                                   not specified
+    S   [  2.00] 2.00
+    P      2.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1        0.457038                      -5.151105664215
+                          2        0.157450                      -5.235617431356
+                          3        0.130137E-02                  -5.246564342251
+                          4        0.531061E-03                  -5.246565033610
+                          5        0.605965E-04                  -5.246565167704
+                          6        0.323545E-04                  -5.246565168968
+                          7        0.365472E-07                  -5.246565169473
+
+ Energy components [Hartree]           Total Energy ::           -5.246565169473
+                                        Band Energy ::           -1.058732656762
+                                     Kinetic Energy ::            3.518928154187
+                                   Potential Energy ::           -8.765493323660
+                                      Virial (-V/T) ::            2.490955467002
+                                        Core Energy ::           -8.429377161979
+                                          XC Energy ::           -1.450183339326
+                                     Coulomb Energy ::            4.632995331832
+                       Total Pseudopotential Energy ::          -11.978048785149
+                       Local Pseudopotential Energy ::          -12.816738149676
+                    Nonlocal Pseudopotential Energy ::            0.838689364526
+                                        Confinement ::            0.297434689834
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.410911          -11.181458
+
+                       1     1          2.000      -0.118455           -3.223332
+
+
+ Total Electron Density at R=0:                                         0.001337
+
+ Guess for atomic kind: O
+
+ Electronic structure
+    Total number of core electrons                                          2.00
+    Total number of valence electrons                                       6.00
+    Total number of electrons                                               8.00
+    Multiplicity                                                   not specified
+    S   [  2.00] 2.00
+    P      4.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1         1.67054                     -14.836051221656
+                          2         2.12470                     -14.897900780399
+                          3        0.100150                     -15.654295189160
+                          4        0.189307E-01                 -15.655828842238
+                          5        0.464435E-02                 -15.655882433232
+                          6        0.259395E-02                 -15.655884790195
+                          7        0.516014E-04                 -15.655885857622
+                          8        0.157374E-05                 -15.655885858066
+                          9        0.783512E-06                 -15.655885858066
+
+ Energy components [Hartree]           Total Energy ::          -15.655885858066
+                                        Band Energy ::           -2.983129541149
+                                     Kinetic Energy ::           11.754767937471
+                                   Potential Energy ::          -27.410653795537
+                                      Virial (-V/T) ::            2.331875366774
+                                        Core Energy ::          -26.153524299614
+                                          XC Energy ::           -3.157392735430
+                                     Coulomb Energy ::           13.655031176977
+                       Total Pseudopotential Energy ::          -37.943031004163
+                       Local Pseudopotential Energy ::          -39.220423834999
+                    Nonlocal Pseudopotential Energy ::            1.277392830837
+                                        Confinement ::            0.347387670777
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.861523          -23.443221
+
+                       1     1          4.000      -0.315021           -8.572160
+
+
+ Total Electron Density at R=0:                                         0.000093
+ Re-scaling the density matrix to get the right number of electrons
+                  # Electrons              Trace(P)               Scaling factor
+                          282               282.011                        1.000
+
+
+ SCF WAVEFUNCTION OPTIMIZATION
+
+  ----------------------------------- OT ---------------------------------------
+  Minimizer      : DIIS                : direct inversion
+                                         in the iterative subspace
+                                         using   7 DIIS vectors
+                                         safer DIIS on
+  Preconditioner : FULL_ALL            : diagonalization, state selective
+  Precond_solver : DEFAULT
+  stepsize       :    0.15000000                  energy_gap     :    0.08000000
+  eps_taylor     :   0.10000E-15                  max_taylor     :             4
+  ----------------------------------- OT ---------------------------------------
+
+  Step     Update method      Time    Convergence         Total energy    Change
+  ------------------------------------------------------------------------------
+     1 OT DIIS     0.15E+00    1.9     0.05381249      -771.1688280339 -7.71E+02
+     2 OT DIIS     0.15E+00    2.5     0.05177409      -780.6544988775 -9.49E+00
+     3 OT DIIS     0.15E+00    2.4     0.03846941      -785.2550202120 -4.60E+00
+     4 OT DIIS     0.15E+00    2.4     0.03347129      -788.0663473611 -2.81E+00
+     5 OT DIIS     0.15E+00    2.4     0.01388535      -790.0652999795 -2.00E+00
+     6 OT DIIS     0.15E+00    2.7     0.01165552      -790.6719573934 -6.07E-01
+     7 OT DIIS     0.15E+00    2.3     0.00833377      -791.0786628231 -4.07E-01
+     8 OT DIIS     0.15E+00    2.4     0.00509416      -791.4000155164 -3.21E-01
+     9 OT DIIS     0.15E+00    2.3     0.00385894      -791.5847684263 -1.85E-01
+    10 OT DIIS     0.15E+00    2.5     0.00307184      -791.6637671751 -7.90E-02
+    11 OT DIIS     0.15E+00    2.6     0.00242449      -791.7420784341 -7.83E-02
+    12 OT DIIS     0.15E+00    2.5     0.00216556      -791.8073904175 -6.53E-02
+    13 OT DIIS     0.15E+00    2.5     0.00198274      -791.8590272220 -5.16E-02
+    14 OT DIIS     0.15E+00    2.4     0.00197031      -791.8956828317 -3.67E-02
+    15 OT DIIS     0.15E+00    2.5     0.00190207      -791.9237962495 -2.81E-02
+    16 OT DIIS     0.15E+00    2.5     0.00186687      -791.9447063686 -2.09E-02
+    17 OT DIIS     0.15E+00    2.4     0.00194433      -791.9735081625 -2.88E-02
+    18 OT DIIS     0.15E+00    2.4     0.00184224      -791.9993031133 -2.58E-02
+    19 OT DIIS     0.15E+00    2.3     0.00175526      -792.0321771747 -3.29E-02
+    20 OT DIIS     0.15E+00    2.4     0.00166157      -792.0706224937 -3.84E-02
+    21 OT DIIS     0.15E+00    2.4     0.00135770      -792.1007242098 -3.01E-02
+    22 OT DIIS     0.15E+00    2.4     0.00135450      -792.1029260345 -2.20E-03
+    23 OT DIIS     0.15E+00    3.0     0.00106426      -792.1200142096 -1.71E-02
+    24 OT DIIS     0.15E+00    3.0     0.00070698      -792.1258596644 -5.85E-03
+    25 OT DIIS     0.15E+00    2.9     0.00071939      -792.1295699522 -3.71E-03
+    26 OT DIIS     0.15E+00    2.3     0.00053853      -792.1334646021 -3.89E-03
+    27 OT DIIS     0.15E+00    2.3     0.00036247      -792.1360887882 -2.62E-03
+    28 OT DIIS     0.15E+00    2.3     0.00030213      -792.1382439164 -2.16E-03
+    29 OT DIIS     0.15E+00    2.4     0.00025347      -792.1398457688 -1.60E-03
+    30 OT DIIS     0.15E+00    2.3     0.00025099      -792.1412382861 -1.39E-03
+    31 OT DIIS     0.15E+00    2.5     0.00021400      -792.1418005429 -5.62E-04
+    32 OT DIIS     0.15E+00    2.6     0.00019827      -792.1427873428 -9.87E-04
+    33 OT DIIS     0.15E+00    3.4     0.00017210      -792.1435573057 -7.70E-04
+    34 OT DIIS     0.15E+00    3.5     0.00017536      -792.1440151638 -4.58E-04
+    35 OT DIIS     0.15E+00    2.7     0.00015317      -792.1444685963 -4.53E-04
+    36 OT DIIS     0.15E+00    2.3     0.00013047      -792.1450920414 -6.23E-04
+    37 OT DIIS     0.15E+00    2.4     0.00011035      -792.1454625849 -3.71E-04
+    38 OT DIIS     0.15E+00    2.4     0.00010643      -792.1458187590 -3.56E-04
+    39 OT DIIS     0.15E+00    2.4     0.00010337      -792.1460066107 -1.88E-04
+    40 OT DIIS     0.15E+00    2.5     0.00008453      -792.1462170253 -2.10E-04
+
+  *** SCF run converged in    40 steps ***
+
+
+  Electronic density on regular grids:       -281.9999997848        0.0000002152
+  Core density on regular grids:              281.9999999823       -0.0000000177
+  Total charge density on r-space grids:        0.0000001975
+  Total charge density g-space grids:           0.0000001975
+
+  Overlap energy of the core charge distribution:               0.00000591200735
+  Self energy of the core charge distribution:              -1553.87652630507228
+  Core Hamiltonian energy:                                    470.70143522662386
+  Hartree energy:                                             452.75875136821207
+  Exchange-correlation energy:                               -161.57677527633820
+  Dispersion energy:                                           -0.15310795077994
+
+  Total energy:                                              -792.14621702534703
+
+  outer SCF iter =    1 RMS gradient =   0.85E-04 energy =       -792.1462170253
+  outer SCF loop converged in   1 iterations or   40 steps
+
+
+ !-----------------------------------------------------------------------------!
+                     Mulliken Population Analysis
+
+ #  Atom  Element  Kind  Atomic population                           Net charge
+       1     Zn       1         11.372865                              0.627135
+       2     Zn       1         11.372384                              0.627616
+       3     Zn       1         11.373238                              0.626762
+       4     Zn       1         11.373391                              0.626609
+       5     Zn       1         11.372780                              0.627220
+       6     Zn       1         11.373336                              0.626664
+       7     H        2          0.923599                              0.076401
+       8     H        2          0.922995                              0.077005
+       9     H        2          0.923283                              0.076717
+      10     H        2          0.923435                              0.076565
+      11     H        2          0.923432                              0.076568
+      12     H        2          0.923309                              0.076691
+      13     C        3          3.784513                              0.215487
+      14     C        3          4.043878                             -0.043878
+      15     C        3          3.911937                              0.088063
+      16     C        3          4.016204                             -0.016204
+      17     C        3          3.782701                              0.217299
+      18     C        3          4.043666                             -0.043666
+      19     C        3          3.910732                              0.089268
+      20     C        3          4.015265                             -0.015265
+      21     C        3          3.783442                              0.216558
+      22     C        3          4.044075                             -0.044075
+      23     C        3          3.911046                              0.088954
+      24     C        3          4.016021                             -0.016021
+      25     C        3          3.783141                              0.216859
+      26     C        3          4.043352                             -0.043352
+      27     C        3          3.911511                              0.088489
+      28     C        3          4.014972                             -0.014972
+      29     C        3          3.782908                              0.217092
+      30     C        3          4.043073                             -0.043073
+      31     C        3          3.913043                              0.086957
+      32     C        3          4.016047                             -0.016047
+      33     C        3          3.783436                              0.216564
+      34     C        3          4.043601                             -0.043601
+      35     C        3          3.911399                              0.088601
+      36     C        3          4.015626                             -0.015626
+      37     O        4          6.292919                             -0.292919
+      38     O        4          6.280169                             -0.280169
+      39     O        4          6.376073                             -0.376073
+      40     O        4          6.292104                             -0.292104
+      41     O        4          6.281379                             -0.281379
+      42     O        4          6.375256                             -0.375256
+      43     O        4          6.291720                             -0.291720
+      44     O        4          6.282462                             -0.282462
+      45     O        4          6.375973                             -0.375973
+      46     O        4          6.290291                             -0.290291
+      47     O        4          6.282829                             -0.282829
+      48     O        4          6.375402                             -0.375402
+      49     O        4          6.290394                             -0.290394
+      50     O        4          6.283130                             -0.283130
+      51     O        4          6.376776                             -0.376776
+      52     O        4          6.290460                             -0.290460
+      53     O        4          6.283668                             -0.283668
+      54     O        4          6.375357                             -0.375357
+ # Total charge                            282.000000                  0.000000
+
+ !-----------------------------------------------------------------------------!
+  
+  Eigenvalues of the occupied subspace spin            1
+ ---------------------------------------------
+      -0.89775487     -0.89745554     -0.89293986     -0.89281973
+      -0.89270706     -0.89249031     -0.82364324     -0.82257726
+      -0.82190655     -0.82186213     -0.82032038     -0.82002908
+      -0.80829898     -0.80818615     -0.80778689     -0.80756757
+      -0.80747376     -0.80648914     -0.66889917     -0.66687004
+      -0.66674682     -0.60048119     -0.59830447     -0.59818069
+      -0.55242725     -0.54753584     -0.54740797     -0.50730381
+      -0.50577361     -0.50564244     -0.44658935     -0.44073794
+      -0.44062523     -0.43823394     -0.43099509     -0.43082451
+      -0.42673223     -0.40593690     -0.40579432     -0.38130947
+      -0.38127914     -0.38036902     -0.38029145     -0.37735780
+      -0.37594720     -0.36189859     -0.35525779     -0.35518851
+      -0.35435446     -0.35433923     -0.35182609     -0.34091075
+      -0.33598865     -0.33590762     -0.32859616     -0.32846594
+      -0.32501992     -0.31323580     -0.31314967     -0.31288664
+      -0.31279368     -0.30654666     -0.30635840     -0.30500162
+      -0.30353174     -0.29882455     -0.29803435     -0.29789237
+      -0.29733619     -0.29465155     -0.29449152     -0.28980902
+      -0.28929991     -0.28879559     -0.28833439     -0.28612742
+      -0.28389385     -0.28176435     -0.28142044     -0.28112149
+      -0.27929718     -0.27786540     -0.27758575     -0.27727532
+      -0.27712630     -0.27682847     -0.27386520     -0.27375714
+      -0.27325098     -0.26957670     -0.26637096     -0.26626568
+      -0.26430613     -0.26199750     -0.26180407     -0.25791257
+      -0.25779567     -0.24824001     -0.24450833     -0.23955239
+      -0.23947750     -0.23864984     -0.23428779     -0.23423576
+      -0.23235394     -0.22391027     -0.21778895     -0.21771631
+      -0.20490979     -0.19521181     -0.19417108     -0.19405918
+      -0.19002457     -0.18987555     -0.17723986     -0.17711763
+      -0.17018459     -0.17005902     -0.16630089     -0.16599803
+      -0.16097841     -0.16094795     -0.16090283     -0.16079304
+      -0.16039325     -0.15242919     -0.14700290     -0.14696035
+      -0.14403792     -0.13291485     -0.13283853     -0.13111184
+      -0.12846055     -0.12592385     -0.12589361     -0.12090988
+      -0.11517109     -0.11510157     -0.08221664     -0.08213869
+      -0.07613580
+ Fermi Energy [eV] :   -2.071760
+  
+  Lowest Eigenvalues of the unoccupied subspace spin            1
+ -----------------------------------------------------
+  Reached convergence in          363  iterations 
+       0.00609616
+  
+ HOMO - LUMO gap [eV] :    2.237645
+
+ -------------------------------------------------------------------------------
+ ----                             MULTIGRID INFO                            ----
+ -------------------------------------------------------------------------------
+ count for grid        1:         100848          cutoff [a.u.]          150.00
+ count for grid        2:          54275          cutoff [a.u.]           50.00
+ count for grid        3:          42951          cutoff [a.u.]           16.67
+ count for grid        4:          18720          cutoff [a.u.]            5.56
+ total gridlevel count  :         216794
+
+ -------------------------------------------------------------------------------
+ -                                                                             -
+ -  BSSE CALCULATION         FRAGMENT CONF: 01        FRAGMENT SUBCONF: 01     -
+ -                           CHARGE =     0           MULTIPLICITY =     1     -
+ -                                                                             -
+ -                 ATOM INDEX                              ATOM NAME           -
+ -                 ----------                              ---------           -
+ -                     55                                   C                  -
+ -                     56                                   O                  -
+ -                     57                                   O                  -
+ -------------------------------------------------------------------------------
+
+ CELL| Volume [angstrom^3]:                                             1375.527
+ CELL| Vector a [angstrom]:       6.917     0.000    -1.071    |a| =       6.999
+ CELL| Vector b [angstrom]:      -3.459    13.046    -7.086    |b| =      15.244
+ CELL| Vector c [angstrom]:       0.000     0.000    15.244    |c| =      15.244
+ CELL| Angle (b,c), alpha [degree]:                                      117.699
+ CELL| Angle (a,c), beta  [degree]:                                       98.805
+ CELL| Angle (a,b), gamma [degree]:                                       98.807
+ CELL| Numerically orthorhombic:                                              NO
+
+ CELL_REF| Volume [angstrom^3]:                                         1375.527
+ CELL_REF| Vector a [angstrom     6.917     0.000    -1.071    |a| =       6.999
+ CELL_REF| Vector b [angstrom    -3.459    13.046    -7.086    |b| =      15.244
+ CELL_REF| Vector c [angstrom     0.000     0.000    15.244    |c| =      15.244
+ CELL_REF| Angle (b,c), alpha [degree]:                                  117.699
+ CELL_REF| Angle (a,c), beta  [degree]:                                   98.805
+ CELL_REF| Angle (a,b), gamma [degree]:                                   98.807
+ CELL_REF| Numerically orthorhombic:                                          NO
+
+ *******************************************************************************
+ *******************************************************************************
+ **                                                                           **
+ **     #####                         ##              ##                      **
+ **    ##   ##            ##          ##              ##                      **
+ **   ##     ##                       ##            ######                    **
+ **   ##     ##  ##   ##  ##   #####  ##  ##   ####   ##    #####    #####    **
+ **   ##     ##  ##   ##  ##  ##      ## ##   ##      ##   ##   ##  ##   ##   **
+ **   ##  ## ##  ##   ##  ##  ##      ####     ###    ##   ######   ######    **
+ **    ##  ###   ##   ##  ##  ##      ## ##      ##   ##   ##       ##        **
+ **     #######   #####   ##   #####  ##  ##  ####    ##    #####   ##        **
+ **           ##                                                    ##        **
+ **                                                                           **
+ **                                                ... make the atoms dance   **
+ **                                                                           **
+ **            Copyright (C) by CP2K developers group (2000 - 2017)           **
+ **                                                                           **
+ *******************************************************************************
+
+ DFT| Spin restricted Kohn-Sham (RKS) calculation                            RKS
+ DFT| Multiplicity                                                             1
+ DFT| Number of spin states                                                    1
+ DFT| Charge                                                                   0
+ DFT| Self-interaction correction (SIC)                                       NO
+ DFT| Cutoffs: density                                              1.000000E-10
+ DFT|          gradient                                             1.000000E-10
+ DFT|          tau                                                  1.000000E-10
+ DFT|          cutoff_smoothing_range                               0.000000E+00
+ DFT| XC density smoothing                                                  NONE
+ DFT| XC derivatives                                                          PW
+ FUNCTIONAL| ROUTINE=NEW
+ FUNCTIONAL| PBE:
+ FUNCTIONAL| J.P.Perdew, K.Burke, M.Ernzerhof, Phys. Rev. Letter, vol. 77, n 18,
+ FUNCTIONAL|  pp. 3865-3868, (1996){spin unpolarized}                           
+ vdW POTENTIAL|                                                   Pair Potential
+ vdW POTENTIAL|          DFT-D3 (Version 3.1)
+ vdW POTENTIAL|          Potential Form: S. Grimme et al, JCP 132: 154104 (2010)
+ vdW POTENTIAL|          BJ Damping: S. Grimme et al, JCC 32: 1456 (2011)
+ vdW POTENTIAL|          Cutoff Radius [Bohr]:                             20.00
+ vdW POTENTIAL|          s6 Scaling Factor:                               1.0000
+ vdW POTENTIAL|          a1 Damping Factor:                               0.4289
+ vdW POTENTIAL|          s8 Scaling Factor:                               0.7875
+ vdW POTENTIAL|          a2 Damping Factor:                               4.4407
+ vdW POTENTIAL|          Cutoff for CN calculation:                   0.1000E-05
+
+ QS| Method:                                                                 GPW
+ QS| Density plane wave grid type                        NON-SPHERICAL FULLSPACE
+ QS| Number of grid levels:                                                    4
+ QS| Density cutoff [a.u.]:                                                150.0
+ QS| Multi grid cutoff [a.u.]: 1) grid level                               150.0
+ QS|                           2) grid level                                50.0
+ QS|                           3) grid level                                16.7
+ QS|                           4) grid level                                 5.6
+ QS| Grid level progression factor:                                          3.0
+ QS| Relative density cutoff [a.u.]:                                        15.0
+ QS| Consistent realspace mapping and integration 
+ QS| Interaction thresholds: eps_pgf_orb:                                1.0E-05
+ QS|                         eps_filter_matrix:                          0.0E+00
+ QS|                         eps_core_charge:                            1.0E-12
+ QS|                         eps_rho_gspace:                             1.0E-10
+ QS|                         eps_rho_rspace:                             1.0E-10
+ QS|                         eps_gvg_rspace:                             1.0E-05
+ QS|                         eps_ppl:                                    1.0E-02
+ QS|                         eps_ppnl:                                   1.0E-07
+
+
+ ATOMIC KIND INFORMATION
+
+  1. Atomic kind: C                                     Number of atoms:       1
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q4
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                5.605331       0.322515
+                                                         2.113016       0.213043
+                                                         0.769911      -0.209686
+                                                         0.348157      -0.219794
+                                                         0.128212      -0.022789
+
+                          1       2    3s                5.605331       0.552234
+                                                         2.113016       0.082072
+                                                         0.769911       0.007843
+                                                         0.348157       0.136893
+                                                         0.128212       0.074283
+
+                          1       3    3px               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+                          1       3    3py               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+                          1       3    3pz               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+
+                          1       4    4px               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+                          1       4    4py               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+                          1       4    4pz               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+
+                          1       5    4dx2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+                          1       5    4dxy              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dxz              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dy2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+                          1       5    4dyz              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dz2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+
+     GTH Potential information for                                    GTH-PBE-q4
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               4.364419
+       Electronic configuration (s p d ...):                               2   2
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.338471   -8.803674    1.339211
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.302576    9.622487
+                   1    0.291507
+
+  2. Atomic kind: O                                     Number of atoms:       2
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q6
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s               10.389228       0.396646
+                                                         3.849621       0.208811
+                                                         1.388401      -0.301641
+                                                         0.496955      -0.274061
+                                                         0.162492      -0.033677
+
+                          1       2    3s               10.389228       0.303673
+                                                         3.849621       0.240943
+                                                         1.388401      -0.313066
+                                                         0.496955      -0.043055
+                                                         0.162492       0.213991
+
+                          1       3    3px              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+                          1       3    3py              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+                          1       3    3pz              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+
+                          1       4    4px              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+                          1       4    4py              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+                          1       4    4pz              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+
+                          1       5    4dx2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+                          1       5    4dxy             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dxz             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dy2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+                          1       5    4dyz             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dz2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+
+     GTH Potential information for                                    GTH-PBE-q6
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               8.360253
+       Electronic configuration (s p d ...):                               2   4
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.244554  -16.667215    2.487311
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.220956   18.337458
+                   1    0.211332
+
+
+ MOLECULE KIND INFORMATION
+
+
+ All atoms are their own molecule, skipping detailed information
+
+
+ TOTAL NUMBERS AND MAXIMUM NUMBERS
+
+  Total number of            - Atomic kinds:                                   2
+                             - Atoms:                                          3
+                             - Shell sets:                                     3
+                             - Shells:                                        15
+                             - Primitive Cartesian functions:                 15
+                             - Cartesian basis functions:                     42
+                             - Spherical basis functions:                     39
+
+  Maximum angular momentum of- Orbital basis functions:                        2
+                             - Local part of the GTH pseudopotential:          2
+                             - Non-local part of the GTH pseudopotential:      0
+
+
+ MODULE QUICKSTEP:  ATOMIC COORDINATES IN angstrom
+
+  Atom  Kind  Element       X           Y           Z          Z(eff)       Mass
+
+       1     1 C    6    5.922650    0.971024    9.644414      4.00      12.0107
+       2     2 O    8    5.627701    2.095563    9.433385      6.00      15.9994
+       3     2 O    8    2.756503   12.905778    2.804537      6.00      15.9994
+
+
+
+
+ SCF PARAMETERS         Density guess:                                    ATOMIC
+                        --------------------------------------------------------
+                        max_scf:                                              50
+                        max_scf_history:                                       0
+                        max_diis:                                              4
+                        --------------------------------------------------------
+                        eps_scf:                                        1.00E-04
+                        eps_scf_history:                                0.00E+00
+                        eps_diis:                                       1.00E-01
+                        eps_eigval:                                     1.00E-05
+                        --------------------------------------------------------
+                        level_shift [a.u.]:                                 0.00
+                        --------------------------------------------------------
+                        Outer loop SCF in use 
+                        No variables optimised in outer loop
+                        eps_scf                                         1.00E-04
+                        max_scf                                                5
+                        No outer loop optimization
+                        step_size                                       5.00E-01
+
+ PW_GRID| Information for grid number                                          9
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                    150.0
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -37      37                Points:          75
+ PW_GRID|   Bounds   2            -80      79                Points:         160
+ PW_GRID|   Bounds   3            -80      79                Points:         160
+ PW_GRID| Volume element (a.u.^3)  0.4835E-02     Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                           480000.0      480000      480000
+ PW_GRID|   G-Rays                                6400.0        6400        6400
+ PW_GRID|   Real Space Points                   480000.0      486400      460800
+
+ PW_GRID| Information for grid number                                         10
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                     50.0
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -22      22                Points:          45
+ PW_GRID|   Bounds   2            -48      47                Points:          96
+ PW_GRID|   Bounds   3            -48      47                Points:          96
+ PW_GRID| Volume element (a.u.^3)  0.2238E-01     Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                           103680.0      103725      103635
+ PW_GRID|   G-Rays                                2304.0        2305        2303
+ PW_GRID|   Real Space Points                   103680.0      110592      101376
+
+ PW_GRID| Information for grid number                                         11
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                     16.7
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -12      12                Points:          25
+ PW_GRID|   Bounds   2            -27      26                Points:          54
+ PW_GRID|   Bounds   3            -27      26                Points:          54
+ PW_GRID| Volume element (a.u.^3)  0.1273         Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                            18225.0       18225       18225
+ PW_GRID|   G-Rays                                 729.0         729         729
+ PW_GRID|   Real Space Points                    18225.0       20412       17496
+
+ PW_GRID| Information for grid number                                         12
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                      5.6
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1             -7       7                Points:          15
+ PW_GRID|   Bounds   2            -16      15                Points:          32
+ PW_GRID|   Bounds   3            -16      15                Points:          32
+ PW_GRID| Volume element (a.u.^3)  0.6043         Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                             3840.0        3855        3825
+ PW_GRID|   G-Rays                                 256.0         257         255
+ PW_GRID|   Real Space Points                     3840.0        4096        3072
+
+ POISSON| Solver                                                        PERIODIC
+ POISSON| Periodicity                                                        XYZ
+
+ RS_GRID| Information for grid number                                          9
+ RS_GRID|   Bounds   1            -37      37                Points:          75
+ RS_GRID|   Bounds   2            -80      79                Points:         160
+ RS_GRID|   Bounds   3            -80      79                Points:         160
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                         10
+ RS_GRID|   Bounds   1            -22      22                Points:          45
+ RS_GRID|   Bounds   2            -48      47                Points:          96
+ RS_GRID|   Bounds   3            -48      47                Points:          96
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                         11
+ RS_GRID|   Bounds   1            -12      12                Points:          25
+ RS_GRID|   Bounds   2            -27      26                Points:          54
+ RS_GRID|   Bounds   3            -27      26                Points:          54
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                         12
+ RS_GRID|   Bounds   1             -7       7                Points:          15
+ RS_GRID|   Bounds   2            -16      15                Points:          32
+ RS_GRID|   Bounds   3            -16      15                Points:          32
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ DISTRIBUTION OF THE PARTICLES (ROWS)
+              Process row      Number of particles         Number of matrix rows
+                        0                        1                            -1
+                        1                        2                            -1
+                      Sum                        3                            -1
+
+ DISTRIBUTION OF THE PARTICLES (COLUMNS)
+              Process col      Number of particles      Number of matrix columns
+                        0                        1                            -1
+                        1                        2                            -1
+                      Sum                        3                            -1
+
+ DISTRIBUTION OF THE NEIGHBOR LISTS
+              Total number of particle pairs:                                 18
+              Total number of matrix elements:                              3042
+              Average number of particle pairs:                                5
+              Maximum number of particle pairs:                                9
+              Average number of matrix element:                              761
+              Maximum number of matrix elements:                            1521
+
+
+ DISTRIBUTION OF THE OVERLAP MATRIX
+              Number  of non-zero blocks:                                      6
+              Percentage non-zero blocks:                                 100.00
+              Average number of blocks per CPU:                                2
+              Maximum number of blocks per CPU:                                3
+              Average number of matrix elements per CPU:                     264
+              Maximum number of matrix elements per CPU:                     517
+
+ Number of electrons:                                                         16
+ Number of occupied orbitals:                                                  8
+ Number of molecular orbitals:                                                 8
+
+ Number of orbital functions:                                                 39
+ Number of independent orbital functions:                                     39
+
+ Extrapolation method: initial_guess
+
+ Atomic guess: The first density matrix is obtained in terms of atomic orbitals
+               and electronic configurations assigned to each atomic kind
+
+ Guess for atomic kind: C
+
+ Electronic structure
+    Total number of core electrons                                          2.00
+    Total number of valence electrons                                       4.00
+    Total number of electrons                                               6.00
+    Multiplicity                                                   not specified
+    S   [  2.00] 2.00
+    P      2.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1        0.457038                      -5.151105664215
+                          2        0.157450                      -5.235617431356
+                          3        0.130137E-02                  -5.246564342251
+                          4        0.531061E-03                  -5.246565033610
+                          5        0.605965E-04                  -5.246565167704
+                          6        0.323545E-04                  -5.246565168968
+                          7        0.365472E-07                  -5.246565169473
+
+ Energy components [Hartree]           Total Energy ::           -5.246565169473
+                                        Band Energy ::           -1.058732656762
+                                     Kinetic Energy ::            3.518928154187
+                                   Potential Energy ::           -8.765493323660
+                                      Virial (-V/T) ::            2.490955467002
+                                        Core Energy ::           -8.429377161979
+                                          XC Energy ::           -1.450183339326
+                                     Coulomb Energy ::            4.632995331832
+                       Total Pseudopotential Energy ::          -11.978048785149
+                       Local Pseudopotential Energy ::          -12.816738149676
+                    Nonlocal Pseudopotential Energy ::            0.838689364526
+                                        Confinement ::            0.297434689834
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.410911          -11.181458
+
+                       1     1          2.000      -0.118455           -3.223332
+
+
+ Total Electron Density at R=0:                                         0.001337
+
+ Guess for atomic kind: O
+
+ Electronic structure
+    Total number of core electrons                                          2.00
+    Total number of valence electrons                                       6.00
+    Total number of electrons                                               8.00
+    Multiplicity                                                   not specified
+    S   [  2.00] 2.00
+    P      4.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1         1.67054                     -14.836051221656
+                          2         2.12470                     -14.897900780399
+                          3        0.100150                     -15.654295189160
+                          4        0.189307E-01                 -15.655828842238
+                          5        0.464435E-02                 -15.655882433232
+                          6        0.259395E-02                 -15.655884790195
+                          7        0.516014E-04                 -15.655885857622
+                          8        0.157374E-05                 -15.655885858066
+                          9        0.783512E-06                 -15.655885858066
+
+ Energy components [Hartree]           Total Energy ::          -15.655885858066
+                                        Band Energy ::           -2.983129541149
+                                     Kinetic Energy ::           11.754767937471
+                                   Potential Energy ::          -27.410653795537
+                                      Virial (-V/T) ::            2.331875366774
+                                        Core Energy ::          -26.153524299614
+                                          XC Energy ::           -3.157392735430
+                                     Coulomb Energy ::           13.655031176977
+                       Total Pseudopotential Energy ::          -37.943031004163
+                       Local Pseudopotential Energy ::          -39.220423834999
+                    Nonlocal Pseudopotential Energy ::            1.277392830837
+                                        Confinement ::            0.347387670777
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.861523          -23.443221
+
+                       1     1          4.000      -0.315021           -8.572160
+
+
+ Total Electron Density at R=0:                                         0.000093
+ Re-scaling the density matrix to get the right number of electrons
+                  # Electrons              Trace(P)               Scaling factor
+                           16                16.000                        1.000
+
+
+ SCF WAVEFUNCTION OPTIMIZATION
+
+  ----------------------------------- OT ---------------------------------------
+  Minimizer      : DIIS                : direct inversion
+                                         in the iterative subspace
+                                         using   7 DIIS vectors
+                                         safer DIIS on
+  Preconditioner : FULL_ALL            : diagonalization, state selective
+  Precond_solver : DEFAULT
+  stepsize       :    0.15000000                  energy_gap     :    0.08000000
+  eps_taylor     :   0.10000E-15                  max_taylor     :             4
+  ----------------------------------- OT ---------------------------------------
+
+  Step     Update method      Time    Convergence         Total energy    Change
+  ------------------------------------------------------------------------------
+     1 OT DIIS     0.15E+00    0.9     0.25324435       -36.6933143261 -3.67E+01
+     2 OT DIIS     0.15E+00    1.2     0.29600159       -36.7174430546 -2.41E-02
+     3 OT DIIS     0.15E+00    1.2     0.09732908       -37.6572734015 -9.40E-01
+     4 OT DIIS     0.15E+00    1.1     0.05027139       -37.7377389019 -8.05E-02
+     5 OT DIIS     0.15E+00    1.2     0.07517443       -37.7362829184  1.46E-03
+     6 OT DIIS     0.15E+00    1.2     0.02008373       -37.7580475955 -2.18E-02
+     7 OT DIIS     0.15E+00    1.2     0.00742806       -37.7613139969 -3.27E-03
+     8 OT DIIS     0.15E+00    1.2     0.00405759       -37.7617005214 -3.87E-04
+     9 OT DIIS     0.15E+00    1.2     0.00129825       -37.7618390207 -1.38E-04
+    10 OT DIIS     0.15E+00    1.2     0.00035730       -37.7618558350 -1.68E-05
+    11 OT DIIS     0.15E+00    1.1     0.00023289       -37.7618579110 -2.08E-06
+    12 OT DIIS     0.15E+00    1.0     0.00013201       -37.7618582975 -3.86E-07
+    13 OT DIIS     0.15E+00    1.0     0.00005060       -37.7618584439 -1.46E-07
+
+  *** SCF run converged in    13 steps ***
+
+
+  Electronic density on regular grids:        -15.9999999688        0.0000000312
+  Core density on regular grids:               15.9999999994       -0.0000000006
+  Total charge density on r-space grids:        0.0000000306
+  Total charge density g-space grids:           0.0000000306
+
+  Overlap energy of the core charge distribution:               0.00000208617292
+  Self energy of the core charge distribution:                -96.38742208476295
+  Core Hamiltonian energy:                                     27.67465345344024
+  Hartree energy:                                              39.59555470446391
+  Exchange-correlation energy:                                 -8.64367857325162
+  Dispersion energy:                                           -0.00096802992140
+
+  Total energy:                                               -37.76185844385889
+
+  outer SCF iter =    1 RMS gradient =   0.51E-04 energy =        -37.7618584439
+  outer SCF loop converged in   1 iterations or   13 steps
+
+
+ !-----------------------------------------------------------------------------!
+                     Mulliken Population Analysis
+
+ #  Atom  Element  Kind  Atomic population                           Net charge
+       1     C        1          3.519705                              0.480295
+       2     O        2          6.241065                             -0.241065
+       3     O        2          6.239230                             -0.239230
+ # Total charge                             16.000000                 -0.000000
+
+ !-----------------------------------------------------------------------------!
+  
+  Eigenvalues of the occupied subspace spin            1
+ ---------------------------------------------
+      -1.06532308     -1.02913364     -0.50475837     -0.46196782
+      -0.45905109     -0.45901356     -0.32895597     -0.32889412
+ Fermi Energy [eV] :   -8.949664
+  
+  Lowest Eigenvalues of the unoccupied subspace spin            1
+ -----------------------------------------------------
+  Reached convergence in          121  iterations 
+      -0.01677818
+  
+ HOMO - LUMO gap [eV] :    8.493107
+
+ -------------------------------------------------------------------------------
+ ----                             MULTIGRID INFO                            ----
+ -------------------------------------------------------------------------------
+ count for grid        1:          21920          cutoff [a.u.]          150.00
+ count for grid        2:          10598          cutoff [a.u.]           50.00
+ count for grid        3:           6608          cutoff [a.u.]           16.67
+ count for grid        4:           1858          cutoff [a.u.]            5.56
+ total gridlevel count  :          40984
+
+ -------------------------------------------------------------------------------
+ -                                                                             -
+ -  BSSE CALCULATION         FRAGMENT CONF: 11        FRAGMENT SUBCONF: 10     -
+ -                           CHARGE =     0           MULTIPLICITY =     1     -
+ -                                                                             -
+ -                 ATOM INDEX                              ATOM NAME           -
+ -                 ----------                              ---------           -
+ -                      1                                   Zn                 -
+ -                      2                                   Zn                 -
+ -                      3                                   Zn                 -
+ -                      4                                   Zn                 -
+ -                      5                                   Zn                 -
+ -                      6                                   Zn                 -
+ -                      7                                   H                  -
+ -                      8                                   H                  -
+ -                      9                                   H                  -
+ -                     10                                   H                  -
+ -                     11                                   H                  -
+ -                     12                                   H                  -
+ -                     13                                   C                  -
+ -                     14                                   C                  -
+ -                     15                                   C                  -
+ -                     16                                   C                  -
+ -                     17                                   C                  -
+ -                     18                                   C                  -
+ -                     19                                   C                  -
+ -                     20                                   C                  -
+ -                     21                                   C                  -
+ -                     22                                   C                  -
+ -                     23                                   C                  -
+ -                     24                                   C                  -
+ -                     25                                   C                  -
+ -                     26                                   C                  -
+ -                     27                                   C                  -
+ -                     28                                   C                  -
+ -                     29                                   C                  -
+ -                     30                                   C                  -
+ -                     31                                   C                  -
+ -                     32                                   C                  -
+ -                     33                                   C                  -
+ -                     34                                   C                  -
+ -                     35                                   C                  -
+ -                     36                                   C                  -
+ -                     37                                   O                  -
+ -                     38                                   O                  -
+ -                     39                                   O                  -
+ -                     40                                   O                  -
+ -                     41                                   O                  -
+ -                     42                                   O                  -
+ -                     43                                   O                  -
+ -                     44                                   O                  -
+ -                     45                                   O                  -
+ -                     46                                   O                  -
+ -                     47                                   O                  -
+ -                     48                                   O                  -
+ -                     49                                   O                  -
+ -                     50                                   O                  -
+ -                     51                                   O                  -
+ -                     52                                   O                  -
+ -                     53                                   O                  -
+ -                     54                                   O                  -
+ -                     55                                   C_ghost            -
+ -                     56                                   O_ghost            -
+ -                     57                                   O_ghost            -
+ -------------------------------------------------------------------------------
+
+ CELL| Volume [angstrom^3]:                                             1375.527
+ CELL| Vector a [angstrom]:       6.917     0.000    -1.071    |a| =       6.999
+ CELL| Vector b [angstrom]:      -3.459    13.046    -7.086    |b| =      15.244
+ CELL| Vector c [angstrom]:       0.000     0.000    15.244    |c| =      15.244
+ CELL| Angle (b,c), alpha [degree]:                                      117.699
+ CELL| Angle (a,c), beta  [degree]:                                       98.805
+ CELL| Angle (a,b), gamma [degree]:                                       98.807
+ CELL| Numerically orthorhombic:                                              NO
+
+ CELL_REF| Volume [angstrom^3]:                                         1375.527
+ CELL_REF| Vector a [angstrom     6.917     0.000    -1.071    |a| =       6.999
+ CELL_REF| Vector b [angstrom    -3.459    13.046    -7.086    |b| =      15.244
+ CELL_REF| Vector c [angstrom     0.000     0.000    15.244    |c| =      15.244
+ CELL_REF| Angle (b,c), alpha [degree]:                                  117.699
+ CELL_REF| Angle (a,c), beta  [degree]:                                   98.805
+ CELL_REF| Angle (a,b), gamma [degree]:                                   98.807
+ CELL_REF| Numerically orthorhombic:                                          NO
+
+ *******************************************************************************
+ *******************************************************************************
+ **                                                                           **
+ **     #####                         ##              ##                      **
+ **    ##   ##            ##          ##              ##                      **
+ **   ##     ##                       ##            ######                    **
+ **   ##     ##  ##   ##  ##   #####  ##  ##   ####   ##    #####    #####    **
+ **   ##     ##  ##   ##  ##  ##      ## ##   ##      ##   ##   ##  ##   ##   **
+ **   ##  ## ##  ##   ##  ##  ##      ####     ###    ##   ######   ######    **
+ **    ##  ###   ##   ##  ##  ##      ## ##      ##   ##   ##       ##        **
+ **     #######   #####   ##   #####  ##  ##  ####    ##    #####   ##        **
+ **           ##                                                    ##        **
+ **                                                                           **
+ **                                                ... make the atoms dance   **
+ **                                                                           **
+ **            Copyright (C) by CP2K developers group (2000 - 2017)           **
+ **                                                                           **
+ *******************************************************************************
+
+ DFT| Spin restricted Kohn-Sham (RKS) calculation                            RKS
+ DFT| Multiplicity                                                             1
+ DFT| Number of spin states                                                    1
+ DFT| Charge                                                                   0
+ DFT| Self-interaction correction (SIC)                                       NO
+ DFT| Cutoffs: density                                              1.000000E-10
+ DFT|          gradient                                             1.000000E-10
+ DFT|          tau                                                  1.000000E-10
+ DFT|          cutoff_smoothing_range                               0.000000E+00
+ DFT| XC density smoothing                                                  NONE
+ DFT| XC derivatives                                                          PW
+ FUNCTIONAL| ROUTINE=NEW
+ FUNCTIONAL| PBE:
+ FUNCTIONAL| J.P.Perdew, K.Burke, M.Ernzerhof, Phys. Rev. Letter, vol. 77, n 18,
+ FUNCTIONAL|  pp. 3865-3868, (1996){spin unpolarized}                           
+ vdW POTENTIAL|                                                   Pair Potential
+ vdW POTENTIAL|          DFT-D3 (Version 3.1)
+ vdW POTENTIAL|          Potential Form: S. Grimme et al, JCP 132: 154104 (2010)
+ vdW POTENTIAL|          BJ Damping: S. Grimme et al, JCC 32: 1456 (2011)
+ vdW POTENTIAL|          Cutoff Radius [Bohr]:                             20.00
+ vdW POTENTIAL|          s6 Scaling Factor:                               1.0000
+ vdW POTENTIAL|          a1 Damping Factor:                               0.4289
+ vdW POTENTIAL|          s8 Scaling Factor:                               0.7875
+ vdW POTENTIAL|          a2 Damping Factor:                               4.4407
+ vdW POTENTIAL|          Cutoff for CN calculation:                   0.1000E-05
+
+ QS| Method:                                                                 GPW
+ QS| Density plane wave grid type                        NON-SPHERICAL FULLSPACE
+ QS| Number of grid levels:                                                    4
+ QS| Density cutoff [a.u.]:                                                150.0
+ QS| Multi grid cutoff [a.u.]: 1) grid level                               150.0
+ QS|                           2) grid level                                50.0
+ QS|                           3) grid level                                16.7
+ QS|                           4) grid level                                 5.6
+ QS| Grid level progression factor:                                          3.0
+ QS| Relative density cutoff [a.u.]:                                        15.0
+ QS| Consistent realspace mapping and integration 
+ QS| Interaction thresholds: eps_pgf_orb:                                1.0E-05
+ QS|                         eps_filter_matrix:                          0.0E+00
+ QS|                         eps_core_charge:                            1.0E-12
+ QS|                         eps_rho_gspace:                             1.0E-10
+ QS|                         eps_rho_rspace:                             1.0E-10
+ QS|                         eps_gvg_rspace:                             1.0E-05
+ QS|                         eps_ppl:                                    1.0E-02
+ QS|                         eps_ppnl:                                   1.0E-07
+
+
+ ATOMIC KIND INFORMATION
+
+  1. Atomic kind: Zn                                    Number of atoms:       6
+
+     Orbital Basis Set                                    DZVP-MOLOPT-SR-GTH-q12
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               7
+       Number of primitive Cartesian functions:                                6
+       Number of Cartesian basis functions:                                   30
+       Number of spherical basis functions:                                   25
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                6.400813       0.070678
+                                                         3.167793      -0.182901
+                                                         1.341704       0.275787
+                                                         0.545418       0.070077
+                                                         0.222222      -0.163015
+                                                         0.079830      -0.058340
+
+                          1       2    3s                6.400813       0.159300
+                                                         3.167793      -0.240359
+                                                         1.341704      -0.028572
+                                                         0.545418      -0.590243
+                                                         0.222222       0.705234
+                                                         0.079830      -0.232595
+
+                          1       3    3px               6.400813       0.044197
+                                                         3.167793      -0.065115
+                                                         1.341704       0.233173
+                                                         0.545418      -0.041743
+                                                         0.222222      -0.119659
+                                                         0.079830      -0.031199
+                          1       3    3py               6.400813       0.044197
+                                                         3.167793      -0.065115
+                                                         1.341704       0.233173
+                                                         0.545418      -0.041743
+                                                         0.222222      -0.119659
+                                                         0.079830      -0.031199
+                          1       3    3pz               6.400813       0.044197
+                                                         3.167793      -0.065115
+                                                         1.341704       0.233173
+                                                         0.545418      -0.041743
+                                                         0.222222      -0.119659
+                                                         0.079830      -0.031199
+
+                          1       4    4px               6.400813       0.240176
+                                                         3.167793      -0.408028
+                                                         1.341704      -0.147214
+                                                         0.545418      -0.102288
+                                                         0.222222       0.357755
+                                                         0.079830      -0.080257
+                          1       4    4py               6.400813       0.240176
+                                                         3.167793      -0.408028
+                                                         1.341704      -0.147214
+                                                         0.545418      -0.102288
+                                                         0.222222       0.357755
+                                                         0.079830      -0.080257
+                          1       4    4pz               6.400813       0.240176
+                                                         3.167793      -0.408028
+                                                         1.341704      -0.147214
+                                                         0.545418      -0.102288
+                                                         0.222222       0.357755
+                                                         0.079830      -0.080257
+
+                          1       5    4dx2              6.400813      12.052935
+                                                         3.167793       4.421864
+                                                         1.341704       0.893324
+                                                         0.545418       0.127232
+                                                         0.222222       0.011466
+                                                         0.079830       0.000178
+                          1       5    4dxy              6.400813      20.876296
+                                                         3.167793       7.658893
+                                                         1.341704       1.547283
+                                                         0.545418       0.220373
+                                                         0.222222       0.019859
+                                                         0.079830       0.000308
+                          1       5    4dxz              6.400813      20.876296
+                                                         3.167793       7.658893
+                                                         1.341704       1.547283
+                                                         0.545418       0.220373
+                                                         0.222222       0.019859
+                                                         0.079830       0.000308
+                          1       5    4dy2              6.400813      12.052935
+                                                         3.167793       4.421864
+                                                         1.341704       0.893324
+                                                         0.545418       0.127232
+                                                         0.222222       0.011466
+                                                         0.079830       0.000178
+                          1       5    4dyz              6.400813      20.876296
+                                                         3.167793       7.658893
+                                                         1.341704       1.547283
+                                                         0.545418       0.220373
+                                                         0.222222       0.019859
+                                                         0.079830       0.000308
+                          1       5    4dz2              6.400813      12.052935
+                                                         3.167793       4.421864
+                                                         1.341704       0.893324
+                                                         0.545418       0.127232
+                                                         0.222222       0.011466
+                                                         0.079830       0.000178
+
+                          1       6    5dx2              6.400813      -3.077244
+                                                         3.167793      -1.397438
+                                                         1.341704      -0.501565
+                                                         0.545418       0.120936
+                                                         0.222222       0.032489
+                                                         0.079830       0.013923
+                          1       6    5dxy              6.400813      -5.329943
+                                                         3.167793      -2.420434
+                                                         1.341704      -0.868735
+                                                         0.545418       0.209468
+                                                         0.222222       0.056272
+                                                         0.079830       0.024116
+                          1       6    5dxz              6.400813      -5.329943
+                                                         3.167793      -2.420434
+                                                         1.341704      -0.868735
+                                                         0.545418       0.209468
+                                                         0.222222       0.056272
+                                                         0.079830       0.024116
+                          1       6    5dy2              6.400813      -3.077244
+                                                         3.167793      -1.397438
+                                                         1.341704      -0.501565
+                                                         0.545418       0.120936
+                                                         0.222222       0.032489
+                                                         0.079830       0.013923
+                          1       6    5dyz              6.400813      -5.329943
+                                                         3.167793      -2.420434
+                                                         1.341704      -0.868735
+                                                         0.545418       0.209468
+                                                         0.222222       0.056272
+                                                         0.079830       0.024116
+                          1       6    5dz2              6.400813      -3.077244
+                                                         3.167793      -1.397438
+                                                         1.341704      -0.501565
+                                                         0.545418       0.120936
+                                                         0.222222       0.032489
+                                                         0.079830       0.013923
+
+                          1       7    5fx3              6.400813      -0.041001
+                                                         3.167793       0.016340
+                                                         1.341704       0.068339
+                                                         0.545418       0.147998
+                                                         0.222222       0.008656
+                                                         0.079830       0.003475
+                          1       7    5fx2y             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fx2z             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fxy2             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fxyz             6.400813      -0.158795
+                                                         3.167793       0.063286
+                                                         1.341704       0.264674
+                                                         0.545418       0.573193
+                                                         0.222222       0.033523
+                                                         0.079830       0.013460
+                          1       7    5fxz2             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fy3              6.400813      -0.041001
+                                                         3.167793       0.016340
+                                                         1.341704       0.068339
+                                                         0.545418       0.147998
+                                                         0.222222       0.008656
+                                                         0.079830       0.003475
+                          1       7    5fy2z             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fyz2             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fz3              6.400813      -0.041001
+                                                         3.167793       0.016340
+                                                         1.341704       0.068339
+                                                         0.545418       0.147998
+                                                         0.222222       0.008656
+                                                         0.079830       0.003475
+
+     GTH Potential information for                                   GTH-PBE-q12
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               1.922338
+       Electronic configuration (s p d ...):                           2   0  10
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.510000
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.400316   11.530041   -8.791898    3.145086
+                                   -8.791898   16.465775   -8.120578
+                                    3.145086   -8.120578    6.445509
+                   1    0.543182    2.597195   -0.594263
+                                   -0.594263    0.703141
+                   2    0.250959  -14.466958
+
+  2. Atomic kind: H                                     Number of atoms:       6
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q1
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               3
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                    5
+       Number of spherical basis functions:                                    5
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s               10.068468      -0.133023
+                                                         2.680223      -0.177618
+                                                         0.791502      -0.258419
+                                                         0.239116      -0.107525
+                                                         0.082193      -0.014019
+
+                          1       2    3s               10.068468       0.344673
+                                                         2.680223       1.819821
+                                                         0.791502      -0.999069
+                                                         0.239116       0.017430
+                                                         0.082193       0.082660
+
+                          1       3    3px              10.068468       0.155326
+                                                         2.680223       0.367157
+                                                         0.791502       0.311480
+                                                         0.239116       0.080105
+                                                         0.082193       0.033440
+                          1       3    3py              10.068468       0.155326
+                                                         2.680223       0.367157
+                                                         0.791502       0.311480
+                                                         0.239116       0.080105
+                                                         0.082193       0.033440
+                          1       3    3pz              10.068468       0.155326
+                                                         2.680223       0.367157
+                                                         0.791502       0.311480
+                                                         0.239116       0.080105
+                                                         0.082193       0.033440
+
+     GTH Potential information for                                    GTH-PBE-q1
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:              12.500000
+       Electronic configuration (s p d ...):                                   1
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.200000   -4.178900    0.724463
+
+  3. Atomic kind: C                                     Number of atoms:      24
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q4
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                5.605331       0.322515
+                                                         2.113016       0.213043
+                                                         0.769911      -0.209686
+                                                         0.348157      -0.219794
+                                                         0.128212      -0.022789
+
+                          1       2    3s                5.605331       0.552234
+                                                         2.113016       0.082072
+                                                         0.769911       0.007843
+                                                         0.348157       0.136893
+                                                         0.128212       0.074283
+
+                          1       3    3px               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+                          1       3    3py               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+                          1       3    3pz               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+
+                          1       4    4px               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+                          1       4    4py               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+                          1       4    4pz               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+
+                          1       5    4dx2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+                          1       5    4dxy              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dxz              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dy2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+                          1       5    4dyz              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dz2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+
+     GTH Potential information for                                    GTH-PBE-q4
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               4.364419
+       Electronic configuration (s p d ...):                               2   2
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.338471   -8.803674    1.339211
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.302576    9.622487
+                   1    0.291507
+
+  4. Atomic kind: O                                     Number of atoms:      18
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q6
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s               10.389228       0.396646
+                                                         3.849621       0.208811
+                                                         1.388401      -0.301641
+                                                         0.496955      -0.274061
+                                                         0.162492      -0.033677
+
+                          1       2    3s               10.389228       0.303673
+                                                         3.849621       0.240943
+                                                         1.388401      -0.313066
+                                                         0.496955      -0.043055
+                                                         0.162492       0.213991
+
+                          1       3    3px              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+                          1       3    3py              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+                          1       3    3pz              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+
+                          1       4    4px              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+                          1       4    4py              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+                          1       4    4pz              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+
+                          1       5    4dx2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+                          1       5    4dxy             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dxz             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dy2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+                          1       5    4dyz             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dz2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+
+     GTH Potential information for                                    GTH-PBE-q6
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               8.360253
+       Electronic configuration (s p d ...):                               2   4
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.244554  -16.667215    2.487311
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.220956   18.337458
+                   1    0.211332
+
+  5. Atomic kind: C_ghost                               Number of atoms:       1
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q4
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                5.605331       0.322515
+                                                         2.113016       0.213043
+                                                         0.769911      -0.209686
+                                                         0.348157      -0.219794
+                                                         0.128212      -0.022789
+
+                          1       2    3s                5.605331       0.552234
+                                                         2.113016       0.082072
+                                                         0.769911       0.007843
+                                                         0.348157       0.136893
+                                                         0.128212       0.074283
+
+                          1       3    3px               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+                          1       3    3py               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+                          1       3    3pz               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+
+                          1       4    4px               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+                          1       4    4py               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+                          1       4    4pz               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+
+                          1       5    4dx2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+                          1       5    4dxy              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dxz              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dy2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+                          1       5    4dyz              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dz2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+
+     The atoms of this atomic kind are GHOST atoms!
+
+  6. Atomic kind: O_ghost                               Number of atoms:       2
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q6
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s               10.389228       0.396646
+                                                         3.849621       0.208811
+                                                         1.388401      -0.301641
+                                                         0.496955      -0.274061
+                                                         0.162492      -0.033677
+
+                          1       2    3s               10.389228       0.303673
+                                                         3.849621       0.240943
+                                                         1.388401      -0.313066
+                                                         0.496955      -0.043055
+                                                         0.162492       0.213991
+
+                          1       3    3px              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+                          1       3    3py              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+                          1       3    3pz              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+
+                          1       4    4px              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+                          1       4    4py              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+                          1       4    4pz              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+
+                          1       5    4dx2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+                          1       5    4dxy             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dxz             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dy2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+                          1       5    4dyz             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dz2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+
+     The atoms of this atomic kind are GHOST atoms!
+
+
+ MOLECULE KIND INFORMATION
+
+
+ All atoms are their own molecule, skipping detailed information
+
+
+ TOTAL NUMBERS AND MAXIMUM NUMBERS
+
+  Total number of            - Atomic kinds:                                   6
+                             - Atoms:                                         57
+                             - Shell sets:                                    57
+                             - Shells:                                       285
+                             - Primitive Cartesian functions:                291
+                             - Cartesian basis functions:                    840
+                             - Spherical basis functions:                    765
+
+  Maximum angular momentum of- Orbital basis functions:                        3
+                             - Local part of the GTH pseudopotential:          2
+                             - Non-local part of the GTH pseudopotential:      4
+
+
+ MODULE QUICKSTEP:  ATOMIC COORDINATES IN angstrom
+
+  Atom  Kind  Element       X           Y           Z          Z(eff)       Mass
+
+       1     1 Zn  30   -0.383625    4.293611    6.600223     12.00      65.3800
+       2     1 Zn  30    2.159815    5.301947    7.779863     12.00      65.3800
+       3     1 Zn  30    4.480115    3.451223    7.517364     12.00      65.3800
+       4     1 Zn  30    3.841016    8.753170    0.486751     12.00      65.3800
+       5     1 Zn  30    1.297611    7.744704   -0.692817     12.00      65.3800
+       6     1 Zn  30   -1.022759    9.595428   -0.430460     12.00      65.3800
+       7     2 H    1    4.482787    0.326675    6.269586      1.00       1.0079
+       8     2 H    1   -0.512588    6.923320    4.505711      1.00       1.0079
+       9     2 H    1    2.859209    5.797047   11.033385      1.00       1.0079
+      10     2 H    1   -1.025431   12.719976    0.817165      1.00       1.0079
+      11     2 H    1    3.969979    6.123462    2.581264      1.00       1.0079
+      12     2 H    1    0.598147    7.249603   -3.946328      1.00       1.0079
+      13     3 C    6    1.847192    2.234671    7.703263      4.00      12.0107
+      14     3 C    6    0.863924    1.115183    7.649961      4.00      12.0107
+      15     3 C    6    6.377042    1.321703    6.419893      4.00      12.0107
+      16     3 C    6    5.556141    0.189038    6.393652      4.00      12.0107
+      17     3 C    6    3.788779    5.091774    4.998794      4.00      12.0107
+      18     3 C    6    2.703758    5.827445    4.288289      4.00      12.0107
+      19     3 C    6    1.413046    6.046098    4.857577      4.00      12.0107
+      20     3 C    6    0.476664    6.743674    4.086548      4.00      12.0107
+      21     3 C    6   -0.261767    5.720467    9.332098      4.00      12.0107
+      22     3 C    6   -1.050040    6.104414   10.537978      4.00      12.0107
+      23     3 C    6    4.520985    5.679110    9.682078      4.00      12.0107
+      24     3 C    6    3.884975    6.114329   10.849971      4.00      12.0107
+      25     3 C    6    1.610199   10.812110   -0.616593      4.00      12.0107
+      26     3 C    6    2.593398   11.931598   -0.563280      4.00      12.0107
+      27     3 C    6   -2.919721   11.725078    0.666788      4.00      12.0107
+      28     3 C    6   -2.098784   12.857612    0.693100      4.00      12.0107
+      29     3 C    6   -0.331423    7.955138    2.088110      4.00      12.0107
+      30     3 C    6    0.753633    7.219336    2.798686      4.00      12.0107
+      31     3 C    6    2.044379    7.000814    2.229468      4.00      12.0107
+      32     3 C    6    2.980692    6.303237    3.000509      4.00      12.0107
+      33     3 C    6    3.719192    7.326184   -2.244900      4.00      12.0107
+      34     3 C    6    4.507397    6.942237   -3.450922      4.00      12.0107
+      35     3 C    6   -1.063664    7.367410   -2.595245      4.00      12.0107
+      36     3 C    6   -0.427584    6.932191   -3.762996      4.00      12.0107
+      37     4 O    8    1.377982    3.429566    7.648309      6.00      15.9994
+      38     4 O    8    3.094194    1.983664    7.794712      6.00      15.9994
+      39     4 O    8    5.787621    2.541908    6.286912      6.00      15.9994
+      40     4 O    8    3.507212    4.603457    6.153450      6.00      15.9994
+      41     4 O    8    4.938109    4.973837    4.458421      6.00      15.9994
+      42     4 O    8    1.036370    5.627970    6.097393      6.00      15.9994
+      43     4 O    8   -0.860163    5.013497    8.441294      6.00      15.9994
+      44     4 O    8    0.954027    6.089542    9.221463      6.00      15.9994
+      45     4 O    8    3.820924    4.876904    8.833239      6.00      15.9994
+      46     4 O    8    2.079374    9.617084   -0.561405      6.00      15.9994
+      47     4 O    8    0.363162   11.062987   -0.707808      6.00      15.9994
+      48     4 O    8   -2.330264   10.504743    0.799992      6.00      15.9994
+      49     4 O    8   -0.049786    8.443194    0.933596      6.00      15.9994
+      50     4 O    8   -1.480753    8.073075    2.628483      6.00      15.9994
+      51     4 O    8    2.420986    7.418942    0.989510      6.00      15.9994
+      52     4 O    8    4.317519    8.032893   -1.354390      6.00      15.9994
+      53     4 O    8    2.503330    6.957109   -2.134407      6.00      15.9994
+      54     4 O    8   -0.363568    8.169486   -1.746335      6.00      15.9994
+      55     5 C    6    5.922650    0.971024    9.644414      0.00      12.0107
+      56     6 O    8    5.627701    2.095563    9.433385      0.00      15.9994
+      57     6 O    8    2.756503   12.905778    2.804537      0.00      15.9994
+
+
+
+
+ SCF PARAMETERS         Density guess:                                    ATOMIC
+                        --------------------------------------------------------
+                        max_scf:                                              50
+                        max_scf_history:                                       0
+                        max_diis:                                              4
+                        --------------------------------------------------------
+                        eps_scf:                                        1.00E-04
+                        eps_scf_history:                                0.00E+00
+                        eps_diis:                                       1.00E-01
+                        eps_eigval:                                     1.00E-05
+                        --------------------------------------------------------
+                        level_shift [a.u.]:                                 0.00
+                        --------------------------------------------------------
+                        Outer loop SCF in use 
+                        No variables optimised in outer loop
+                        eps_scf                                         1.00E-04
+                        max_scf                                                5
+                        No outer loop optimization
+                        step_size                                       5.00E-01
+
+ PW_GRID| Information for grid number                                         13
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                    150.0
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -37      37                Points:          75
+ PW_GRID|   Bounds   2            -80      79                Points:         160
+ PW_GRID|   Bounds   3            -80      79                Points:         160
+ PW_GRID| Volume element (a.u.^3)  0.4835E-02     Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                           480000.0      480000      480000
+ PW_GRID|   G-Rays                                6400.0        6400        6400
+ PW_GRID|   Real Space Points                   480000.0      486400      460800
+
+ PW_GRID| Information for grid number                                         14
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                     50.0
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -22      22                Points:          45
+ PW_GRID|   Bounds   2            -48      47                Points:          96
+ PW_GRID|   Bounds   3            -48      47                Points:          96
+ PW_GRID| Volume element (a.u.^3)  0.2238E-01     Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                           103680.0      103725      103635
+ PW_GRID|   G-Rays                                2304.0        2305        2303
+ PW_GRID|   Real Space Points                   103680.0      110592      101376
+
+ PW_GRID| Information for grid number                                         15
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                     16.7
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -12      12                Points:          25
+ PW_GRID|   Bounds   2            -27      26                Points:          54
+ PW_GRID|   Bounds   3            -27      26                Points:          54
+ PW_GRID| Volume element (a.u.^3)  0.1273         Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                            18225.0       18225       18225
+ PW_GRID|   G-Rays                                 729.0         729         729
+ PW_GRID|   Real Space Points                    18225.0       20412       17496
+
+ PW_GRID| Information for grid number                                         16
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                      5.6
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1             -7       7                Points:          15
+ PW_GRID|   Bounds   2            -16      15                Points:          32
+ PW_GRID|   Bounds   3            -16      15                Points:          32
+ PW_GRID| Volume element (a.u.^3)  0.6043         Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                             3840.0        3855        3825
+ PW_GRID|   G-Rays                                 256.0         257         255
+ PW_GRID|   Real Space Points                     3840.0        4096        3072
+
+ POISSON| Solver                                                        PERIODIC
+ POISSON| Periodicity                                                        XYZ
+
+ RS_GRID| Information for grid number                                         13
+ RS_GRID|   Bounds   1            -37      37                Points:          75
+ RS_GRID|   Bounds   2            -80      79                Points:         160
+ RS_GRID|   Bounds   3            -80      79                Points:         160
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                         14
+ RS_GRID|   Bounds   1            -22      22                Points:          45
+ RS_GRID|   Bounds   2            -48      47                Points:          96
+ RS_GRID|   Bounds   3            -48      47                Points:          96
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                         15
+ RS_GRID|   Bounds   1            -12      12                Points:          25
+ RS_GRID|   Bounds   2            -27      26                Points:          54
+ RS_GRID|   Bounds   3            -27      26                Points:          54
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                         16
+ RS_GRID|   Bounds   1             -7       7                Points:          15
+ RS_GRID|   Bounds   2            -16      15                Points:          32
+ RS_GRID|   Bounds   3            -16      15                Points:          32
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ DISTRIBUTION OF THE PARTICLES (ROWS)
+              Process row      Number of particles         Number of matrix rows
+                        0                       29                            -1
+                        1                       28                            -1
+                      Sum                       57                            -1
+
+ DISTRIBUTION OF THE PARTICLES (COLUMNS)
+              Process col      Number of particles      Number of matrix columns
+                        0                       29                            -1
+                        1                       28                            -1
+                      Sum                       57                            -1
+
+ DISTRIBUTION OF THE NEIGHBOR LISTS
+              Total number of particle pairs:                               6196
+              Total number of matrix elements:                           1216356
+              Average number of particle pairs:                             1549
+              Maximum number of particle pairs:                             1690
+              Average number of matrix element:                           304089
+              Maximum number of matrix elements:                          314098
+
+
+ DISTRIBUTION OF THE OVERLAP MATRIX
+              Number  of non-zero blocks:                                   1653
+              Percentage non-zero blocks:                                 100.00
+              Average number of blocks per CPU:                              414
+              Maximum number of blocks per CPU:                              435
+              Average number of matrix elements per CPU:                   74602
+              Maximum number of matrix elements per CPU:                   76644
+
+ Number of electrons:                                                        282
+ Number of occupied orbitals:                                                141
+ Number of molecular orbitals:                                               141
+
+ Number of orbital functions:                                                765
+ Number of independent orbital functions:                                    765
+
+ Extrapolation method: initial_guess
+
+ Atomic guess: The first density matrix is obtained in terms of atomic orbitals
+               and electronic configurations assigned to each atomic kind
+
+ Guess for atomic kind: Zn
+
+ Electronic structure
+    Total number of core electrons                                         18.00
+    Total number of valence electrons                                      12.00
+    Total number of electrons                                              30.00
+    Multiplicity                                                   not specified
+    S   [  2.00  2.00  2.00] 2.00
+    P   [  6.00  6.00]
+    D     10.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1         1.62924                     -59.451394251983
+                          2         9.44946                     -57.380718340026
+                          3         1.20534                     -60.073283596570
+                          4        0.228441                     -60.149512613300
+                          5        0.659017E-01                 -60.153075514012
+                          6        0.364244E-01                 -60.153290281981
+                          7        0.826658E-01                 -60.152916515694
+                          8        0.577629E-03                 -60.153383695723
+                          9        0.361798E-03                 -60.153383709870
+                         10        0.208007E-03                 -60.153383715984
+                         11        0.873205E-04                 -60.153383718472
+                         12        0.217219E-05                 -60.153383719003
+                         13        0.826432E-08                 -60.153383719004
+
+ Energy components [Hartree]           Total Energy ::          -60.153383719004
+                                        Band Energy ::           -3.832693908022
+                                     Kinetic Energy ::           84.396829637188
+                                   Potential Energy ::         -144.550213356191
+                                      Virial (-V/T) ::            1.712744589786
+                                        Core Energy ::         -110.535288508001
+                                          XC Energy ::           -8.666206286402
+                                     Coulomb Energy ::           59.048111075399
+                       Total Pseudopotential Energy ::         -195.030087576096
+                       Local Pseudopotential Energy ::         -135.966032502182
+                    Nonlocal Pseudopotential Energy ::          -59.064055073914
+                                        Confinement ::            0.979694309070
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.191113           -5.200458
+
+                       1     2         10.000      -0.345047           -9.389199
+
+
+ Total Electron Density at R=0:                                         0.000033
+
+ Guess for atomic kind: H
+
+ Electronic structure
+    Total number of core electrons                                          0.00
+    Total number of valence electrons                                       1.00
+    Total number of electrons                                               1.00
+    Multiplicity                                                   not specified
+    S      1.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1        0.250972E-02                  -0.375256815885
+                          2        0.570752E-04                  -0.375258666164
+                          3        0.832405E-09                  -0.375258667122
+
+ Energy components [Hartree]           Total Energy ::           -0.375258667122
+                                        Band Energy ::           -0.076317618391
+                                     Kinetic Energy ::            0.771356566341
+                                   Potential Energy ::           -1.146615233463
+                                      Virial (-V/T) ::            1.486491829455
+                                        Core Energy ::           -0.456090715790
+                                          XC Energy ::           -0.314218627334
+                                     Coulomb Energy ::            0.395050676003
+                       Total Pseudopotential Energy ::           -1.238482237174
+                       Local Pseudopotential Energy ::           -1.238482237174
+                    Nonlocal Pseudopotential Energy ::            0.000000000000
+                                        Confinement ::            0.110349550431
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          1.000      -0.076318           -2.076708
+
+
+ Total Electron Density at R=0:                                         0.425022
+
+ Guess for atomic kind: C
+
+ Electronic structure
+    Total number of core electrons                                          2.00
+    Total number of valence electrons                                       4.00
+    Total number of electrons                                               6.00
+    Multiplicity                                                   not specified
+    S   [  2.00] 2.00
+    P      2.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1        0.457038                      -5.151105664215
+                          2        0.157450                      -5.235617431356
+                          3        0.130137E-02                  -5.246564342251
+                          4        0.531061E-03                  -5.246565033610
+                          5        0.605965E-04                  -5.246565167704
+                          6        0.323545E-04                  -5.246565168968
+                          7        0.365472E-07                  -5.246565169473
+
+ Energy components [Hartree]           Total Energy ::           -5.246565169473
+                                        Band Energy ::           -1.058732656762
+                                     Kinetic Energy ::            3.518928154187
+                                   Potential Energy ::           -8.765493323660
+                                      Virial (-V/T) ::            2.490955467002
+                                        Core Energy ::           -8.429377161979
+                                          XC Energy ::           -1.450183339326
+                                     Coulomb Energy ::            4.632995331832
+                       Total Pseudopotential Energy ::          -11.978048785149
+                       Local Pseudopotential Energy ::          -12.816738149676
+                    Nonlocal Pseudopotential Energy ::            0.838689364526
+                                        Confinement ::            0.297434689834
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.410911          -11.181458
+
+                       1     1          2.000      -0.118455           -3.223332
+
+
+ Total Electron Density at R=0:                                         0.001337
+
+ Guess for atomic kind: O
+
+ Electronic structure
+    Total number of core electrons                                          2.00
+    Total number of valence electrons                                       6.00
+    Total number of electrons                                               8.00
+    Multiplicity                                                   not specified
+    S   [  2.00] 2.00
+    P      4.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1         1.67054                     -14.836051221656
+                          2         2.12470                     -14.897900780399
+                          3        0.100150                     -15.654295189160
+                          4        0.189307E-01                 -15.655828842238
+                          5        0.464435E-02                 -15.655882433232
+                          6        0.259395E-02                 -15.655884790195
+                          7        0.516014E-04                 -15.655885857622
+                          8        0.157374E-05                 -15.655885858066
+                          9        0.783512E-06                 -15.655885858066
+
+ Energy components [Hartree]           Total Energy ::          -15.655885858066
+                                        Band Energy ::           -2.983129541149
+                                     Kinetic Energy ::           11.754767937471
+                                   Potential Energy ::          -27.410653795537
+                                      Virial (-V/T) ::            2.331875366774
+                                        Core Energy ::          -26.153524299614
+                                          XC Energy ::           -3.157392735430
+                                     Coulomb Energy ::           13.655031176977
+                       Total Pseudopotential Energy ::          -37.943031004163
+                       Local Pseudopotential Energy ::          -39.220423834999
+                    Nonlocal Pseudopotential Energy ::            1.277392830837
+                                        Confinement ::            0.347387670777
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.861523          -23.443221
+
+                       1     1          4.000      -0.315021           -8.572160
+
+
+ Total Electron Density at R=0:                                         0.000093
+
+ Guess for atomic kind: C_ghost
+
+ Electronic structure
+    Total number of core electrons                                          0.00
+    Total number of valence electrons                                       0.00
+    Total number of electrons                                               0.00
+    Multiplicity                                                   not specified
+    S
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1         0.00000                       0.000000000000
+
+ Energy components [Hartree]           Total Energy ::            0.000000000000
+                                        Band Energy ::            0.000000000000
+                                     Kinetic Energy ::            0.000000000000
+                                   Potential Energy ::            0.000000000000
+                                        Core Energy ::            0.000000000000
+                                     Coulomb Energy ::            0.000000000000
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+
+ Total Electron Density at R=0:                                         0.000000
+
+ Guess for atomic kind: O_ghost
+
+ Electronic structure
+    Total number of core electrons                                          0.00
+    Total number of valence electrons                                       0.00
+    Total number of electrons                                               0.00
+    Multiplicity                                                   not specified
+    S
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1         0.00000                       0.000000000000
+
+ Energy components [Hartree]           Total Energy ::            0.000000000000
+                                        Band Energy ::            0.000000000000
+                                     Kinetic Energy ::            0.000000000000
+                                   Potential Energy ::            0.000000000000
+                                        Core Energy ::            0.000000000000
+                                     Coulomb Energy ::            0.000000000000
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+
+ Total Electron Density at R=0:                                         0.000000
+ Re-scaling the density matrix to get the right number of electrons
+                  # Electrons              Trace(P)               Scaling factor
+                          282               282.011                        1.000
+
+
+ SCF WAVEFUNCTION OPTIMIZATION
+
+  ----------------------------------- OT ---------------------------------------
+  Minimizer      : DIIS                : direct inversion
+                                         in the iterative subspace
+                                         using   7 DIIS vectors
+                                         safer DIIS on
+  Preconditioner : FULL_ALL            : diagonalization, state selective
+  Precond_solver : DEFAULT
+  stepsize       :    0.15000000                  energy_gap     :    0.08000000
+  eps_taylor     :   0.10000E-15                  max_taylor     :             4
+  ----------------------------------- OT ---------------------------------------
+
+  Step     Update method      Time    Convergence         Total energy    Change
+  ------------------------------------------------------------------------------
+     1 OT DIIS     0.15E+00    2.0     0.05246557      -771.2716195620 -7.71E+02
+     2 OT DIIS     0.15E+00    3.0     0.05058296      -780.6705393443 -9.40E+00
+     3 OT DIIS     0.15E+00    2.5     0.03832178      -785.2997010921 -4.63E+00
+     4 OT DIIS     0.15E+00    2.4     0.03857937      -787.6504274535 -2.35E+00
+     5 OT DIIS     0.15E+00    2.4     0.01444448      -789.9647701065 -2.31E+00
+     6 OT DIIS     0.15E+00    2.4     0.01116930      -790.6483452708 -6.84E-01
+     7 OT DIIS     0.15E+00    2.4     0.00816686      -791.0525033148 -4.04E-01
+     8 OT DIIS     0.15E+00    2.4     0.00505056      -791.3796273200 -3.27E-01
+     9 OT DIIS     0.15E+00    2.4     0.00367802      -791.5699358627 -1.90E-01
+    10 OT DIIS     0.15E+00    2.4     0.00292749      -791.6461371135 -7.62E-02
+    11 OT DIIS     0.15E+00    2.4     0.00222610      -791.7176793961 -7.15E-02
+    12 OT DIIS     0.15E+00    2.8     0.00182501      -791.7735878566 -5.59E-02
+    13 OT DIIS     0.15E+00    3.4     0.00143065      -791.8162619831 -4.27E-02
+    14 OT DIIS     0.15E+00    3.0     0.00131072      -791.8431474858 -2.69E-02
+    15 OT DIIS     0.15E+00    2.7     0.00115995      -791.8641516539 -2.10E-02
+    16 OT DIIS     0.15E+00    2.4     0.00103133      -791.8790371164 -1.49E-02
+    17 OT DIIS     0.15E+00    3.1     0.00087454      -791.8924271739 -1.34E-02
+    18 OT DIIS     0.15E+00    2.8     0.00081295      -791.9029853534 -1.06E-02
+    19 OT DIIS     0.15E+00    2.8     0.00071684      -791.9107359408 -7.75E-03
+    20 OT DIIS     0.15E+00    3.1     0.00061173      -791.9182117461 -7.48E-03
+    21 OT DIIS     0.15E+00    3.0     0.00053582      -791.9246977728 -6.49E-03
+    22 OT DIIS     0.15E+00    2.7     0.00053046      -791.9292470859 -4.55E-03
+    23 OT DIIS     0.15E+00    2.4     0.00045679      -791.9328078632 -3.56E-03
+    24 OT DIIS     0.15E+00    2.6     0.00042229      -791.9361746037 -3.37E-03
+    25 OT DIIS     0.15E+00    2.5     0.00040155      -791.9386762669 -2.50E-03
+    26 OT DIIS     0.15E+00    2.4     0.00037420      -791.9410307119 -2.35E-03
+    27 OT DIIS     0.15E+00    2.4     0.00036218      -791.9426601026 -1.63E-03
+    28 OT DIIS     0.15E+00    2.4     0.00035868      -791.9434057671 -7.46E-04
+    29 OT DIIS     0.15E+00    2.4     0.00036481      -791.9434500481 -4.43E-05
+    30 OT DIIS     0.15E+00    2.4     0.00036652      -791.9434695072 -1.95E-05
+    31 OT DIIS     0.15E+00    2.5     0.00036541      -791.9437301566 -2.61E-04
+    32 OT DIIS     0.15E+00    2.5     0.00037057      -791.9448208965 -1.09E-03
+    33 OT DIIS     0.15E+00    2.5     0.00036081      -791.9453967588 -5.76E-04
+    34 OT DIIS     0.15E+00    2.4     0.00035859      -791.9463900935 -9.93E-04
+    35 OT DIIS     0.15E+00    2.5     0.00035350      -791.9464795513 -8.95E-05
+    36 OT SD       0.15E+00    2.4     0.00037260      -791.9479767160 -1.50E-03
+    37 OT SD       0.15E+00    2.4     0.00043373      -791.9501227483 -2.15E-03
+    38 OT SD       0.15E+00    2.6     0.00064882      -791.9522009397 -2.08E-03
+    39 OT SD       0.15E+00    2.5     0.00137474      -791.9520185474  1.82E-04
+    40 OT DIIS     0.15E+00    2.4     0.00342357      -791.9335047930  1.85E-02
+    41 OT SD       0.15E+00    2.5     0.00041211      -791.9408043672 -7.30E-03
+    42 OT SD       0.15E+00    2.5     0.00048126      -791.9420178941 -1.21E-03
+    43 OT DIIS     0.15E+00    2.5     0.00083994      -791.9419511191  6.68E-05
+    44 OT DIIS     0.15E+00    2.4     0.00028429      -791.9416222606  3.29E-04
+    45 OT DIIS     0.15E+00    2.5     0.00025002      -791.9422824634 -6.60E-04
+    46 OT DIIS     0.15E+00    2.4     0.00021878      -791.9446001935 -2.32E-03
+    47 OT DIIS     0.15E+00    2.6     0.00020170      -791.9449162548 -3.16E-04
+    48 OT DIIS     0.15E+00    2.5     0.00018570      -791.9465599529 -1.64E-03
+    49 OT DIIS     0.15E+00    2.4     0.00017568      -791.9477512887 -1.19E-03
+    50 OT DIIS     0.15E+00    2.4     0.00016316      -791.9486725784 -9.21E-04
+
+  Leaving inner SCF loop after reaching    50 steps.
+
+
+  Electronic density on regular grids:       -281.9999997847        0.0000002153
+  Core density on regular grids:              281.9999999823       -0.0000000177
+  Total charge density on r-space grids:        0.0000001975
+  Total charge density g-space grids:           0.0000001975
+
+  Overlap energy of the core charge distribution:               0.00000591200735
+  Self energy of the core charge distribution:              -1553.87652630507228
+  Core Hamiltonian energy:                                    470.89400706769266
+  Hartree energy:                                             452.74115748039179
+  Exchange-correlation energy:                               -161.55420878261648
+  Dispersion energy:                                           -0.15310795077994
+
+  Total energy:                                              -791.94867257837700
+
+  outer SCF iter =    1 RMS gradient =   0.16E-03 energy =       -791.9486725784
+
+  ----------------------------------- OT ---------------------------------------
+  Minimizer      : DIIS                : direct inversion
+                                         in the iterative subspace
+                                         using   7 DIIS vectors
+                                         safer DIIS on
+  Preconditioner : FULL_ALL            : diagonalization, state selective
+  Precond_solver : DEFAULT
+  stepsize       :    0.15000000                  energy_gap     :    0.08000000
+  eps_taylor     :   0.10000E-15                  max_taylor     :             4
+  ----------------------------------- OT ---------------------------------------
+
+  Step     Update method      Time    Convergence         Total energy    Change
+  ------------------------------------------------------------------------------
+     1 OT DIIS     0.15E+00    5.3     0.00056423      -791.9495060954 -8.34E-04
+     2 OT DIIS     0.15E+00    2.5     0.00037212      -791.9533881105 -3.88E-03
+     3 OT DIIS     0.15E+00    2.5     0.00043463      -791.9549623892 -1.57E-03
+     4 OT DIIS     0.15E+00    2.4     0.00030512      -791.9563577849 -1.40E-03
+     5 OT SD       0.15E+00    2.5     0.00031644      -791.9566594069 -3.02E-04
+     6 OT SD       0.15E+00    2.4     0.00047310      -791.9585660478 -1.91E-03
+     7 OT SD       0.15E+00    2.9     0.00076292      -791.9628628601 -4.30E-03
+     8 OT SD       0.15E+00    2.6     0.00125751      -791.9731508318 -1.03E-02
+     9 OT SD       0.15E+00    2.6     0.00205709      -791.9954969189 -2.23E-02
+    10 OT SD       0.15E+00    2.5     0.00317434      -792.0326135990 -3.71E-02
+    11 OT SD       0.15E+00    2.6     0.00458786      -792.0543660092 -2.18E-02
+    12 OT DIIS     0.15E+00    3.5     0.00677877      -791.9985202008  5.58E-02
+    13 OT DIIS     0.15E+00    3.2     0.00040333      -791.9566476569  4.19E-02
+    14 OT SD       0.15E+00    2.4     0.00139064      -791.9654642826 -8.82E-03
+    15 OT SD       0.15E+00    2.4     0.00200262      -791.9822625937 -1.68E-02
+    16 OT SD       0.15E+00    2.4     0.00276962      -792.0196895199 -3.74E-02
+    17 OT SD       0.15E+00    2.4     0.00330972      -792.0619932808 -4.23E-02
+    18 OT SD       0.15E+00    2.4     0.00380083      -792.0903575685 -2.84E-02
+    19 OT DIIS     0.15E+00    2.4     0.00511809      -792.0532256690  3.71E-02
+    20 OT DIIS     0.15E+00    2.4     0.00166497      -791.9729855381  8.02E-02
+    21 OT DIIS     0.15E+00    2.4     0.00279172      -792.0460798567 -7.31E-02
+    22 OT DIIS     0.15E+00    2.4     0.00089123      -792.1423854588 -9.63E-02
+    23 OT DIIS     0.15E+00    2.4     0.00049667      -792.1456834816 -3.30E-03
+    24 OT DIIS     0.15E+00    2.4     0.00028991      -792.1468554904 -1.17E-03
+    25 OT SD       0.15E+00    2.8     0.00036229      -792.1465298700  3.26E-04
+    26 OT DIIS     0.15E+00    2.7     0.00040983      -792.1467984946 -2.69E-04
+    27 OT DIIS     0.15E+00    2.5     0.00048097      -792.1459680575  8.30E-04
+    28 OT DIIS     0.15E+00    2.7     0.00005873      -792.1474366957 -1.47E-03
+
+  *** SCF run converged in    28 steps ***
+
+
+  Electronic density on regular grids:       -281.9999997847        0.0000002153
+  Core density on regular grids:              281.9999999823       -0.0000000177
+  Total charge density on r-space grids:        0.0000001975
+  Total charge density g-space grids:           0.0000001975
+
+  Overlap energy of the core charge distribution:               0.00000591200735
+  Self energy of the core charge distribution:              -1553.87652630507228
+  Core Hamiltonian energy:                                    470.69889251189744
+  Hartree energy:                                             452.76067543273734
+  Exchange-correlation energy:                               -161.57737629651700
+  Dispersion energy:                                           -0.15310795077994
+
+  Total energy:                                              -792.14743669572727
+
+  outer SCF iter =    2 RMS gradient =   0.59E-04 energy =       -792.1474366957
+  outer SCF loop converged in   2 iterations or   78 steps
+
+
+ !-----------------------------------------------------------------------------!
+                     Mulliken Population Analysis
+
+ #  Atom  Element  Kind  Atomic population                           Net charge
+       1     Zn       1         11.376643                              0.623357
+       2     Zn       1         11.372518                              0.627482
+       3     Zn       1         11.364407                              0.635593
+       4     Zn       1         11.373296                              0.626704
+       5     Zn       1         11.373178                              0.626822
+       6     Zn       1         11.373584                              0.626416
+       7     H        2          0.923287                              0.076713
+       8     H        2          0.923118                              0.076882
+       9     H        2          0.923050                              0.076950
+      10     H        2          0.923537                              0.076463
+      11     H        2          0.923070                              0.076930
+      12     H        2          0.923133                              0.076867
+      13     C        3          3.784144                              0.215856
+      14     C        3          4.043249                             -0.043249
+      15     C        3          3.913663                              0.086337
+      16     C        3          4.016666                             -0.016666
+      17     C        3          3.783642                              0.216358
+      18     C        3          4.043040                             -0.043040
+      19     C        3          3.911708                              0.088292
+      20     C        3          4.015651                             -0.015651
+      21     C        3          3.784055                              0.215945
+      22     C        3          4.043445                             -0.043445
+      23     C        3          3.911900                              0.088100
+      24     C        3          4.015515                             -0.015515
+      25     C        3          3.783012                              0.216988
+      26     C        3          4.044084                             -0.044084
+      27     C        3          3.911967                              0.088033
+      28     C        3          4.014647                             -0.014647
+      29     C        3          3.783286                              0.216714
+      30     C        3          4.043217                             -0.043217
+      31     C        3          3.911892                              0.088108
+      32     C        3          4.016034                             -0.016034
+      33     C        3          3.783709                              0.216291
+      34     C        3          4.043640                             -0.043640
+      35     C        3          3.911811                              0.088189
+      36     C        3          4.015559                             -0.015559
+      37     O        4          6.290840                             -0.290840
+      38     O        4          6.282222                             -0.282222
+      39     O        4          6.375663                             -0.375663
+      40     O        4          6.289607                             -0.289607
+      41     O        4          6.282163                             -0.282163
+      42     O        4          6.375626                             -0.375626
+      43     O        4          6.291559                             -0.291559
+      44     O        4          6.282840                             -0.282840
+      45     O        4          6.375931                             -0.375931
+      46     O        4          6.291059                             -0.291059
+      47     O        4          6.282594                             -0.282594
+      48     O        4          6.375512                             -0.375512
+      49     O        4          6.290624                             -0.290624
+      50     O        4          6.282451                             -0.282451
+      51     O        4          6.375574                             -0.375574
+      52     O        4          6.291120                             -0.291120
+      53     O        4          6.282746                             -0.282746
+      54     O        4          6.375608                             -0.375608
+      55     C        5         -0.000066                              0.000066
+      56     O        6          0.003883                             -0.003883
+      57     O        6          0.000085                             -0.000085
+ # Total charge                            282.000000                  0.000000
+
+ !-----------------------------------------------------------------------------!
+  
+  Eigenvalues of the occupied subspace spin            1
+ ---------------------------------------------
+      -0.89779355     -0.89733064     -0.89313814     -0.89269739
+      -0.89257260     -0.89214505     -0.82366709     -0.82286708
+      -0.82210055     -0.82171452     -0.82056652     -0.82015955
+      -0.80853863     -0.80795744     -0.80772829     -0.80746868
+      -0.80720721     -0.80634482     -0.66901087     -0.66704812
+      -0.66673010     -0.60059625     -0.59848236     -0.59812575
+      -0.55250183     -0.54771325     -0.54736230     -0.50739681
+      -0.50590047     -0.50557212     -0.44665968     -0.44087342
+      -0.44059352     -0.43824888     -0.43108124     -0.43078187
+      -0.42677252     -0.40601223     -0.40579293     -0.38135967
+      -0.38109293     -0.38047422     -0.38030065     -0.37739800
+      -0.37596087     -0.36183555     -0.35520027     -0.35482331
+      -0.35440553     -0.35432742     -0.35163211     -0.34092449
+      -0.33602166     -0.33580794     -0.32862048     -0.32844861
+      -0.32500699     -0.31327272     -0.31306026     -0.31294006
+      -0.31273645     -0.30649517     -0.30632187     -0.30492887
+      -0.30349081     -0.29875624     -0.29792570     -0.29783034
+      -0.29729383     -0.29459137     -0.29450404     -0.28967652
+      -0.28921670     -0.28870366     -0.28827201     -0.28602059
+      -0.28379501     -0.28172526     -0.28131021     -0.28107580
+      -0.27920782     -0.27778549     -0.27740669     -0.27727656
+      -0.27692815     -0.27680357     -0.27376927     -0.27365289
+      -0.27319814     -0.26946441     -0.26639373     -0.26618788
+      -0.26422517     -0.26197749     -0.26174257     -0.25791568
+      -0.25782679     -0.24822649     -0.24453010     -0.23961498
+      -0.23938305     -0.23856385     -0.23436312     -0.23424738
+      -0.23238453     -0.22387271     -0.21778571     -0.21770391
+      -0.20490368     -0.19521360     -0.19416616     -0.19412269
+      -0.19005715     -0.18998972     -0.17724917     -0.17706445
+      -0.17015962     -0.16987901     -0.16617896     -0.16599625
+      -0.16100551     -0.16076340     -0.16063082     -0.16043395
+      -0.16026582     -0.15238725     -0.14705654     -0.14680008
+      -0.14409058     -0.13309883     -0.13276425     -0.13114439
+      -0.12847816     -0.12606364     -0.12589351     -0.12095440
+      -0.11528628     -0.11515253     -0.08241379     -0.08210059
+      -0.07625167
+ Fermi Energy [eV] :   -2.074913
+  
+  Lowest Eigenvalues of the unoccupied subspace spin            1
+ -----------------------------------------------------
+  Reached convergence in          705  iterations 
+       0.00590638
+  
+ HOMO - LUMO gap [eV] :    2.235634
+
+ -------------------------------------------------------------------------------
+ ----                             MULTIGRID INFO                            ----
+ -------------------------------------------------------------------------------
+ count for grid        1:         213102          cutoff [a.u.]          150.00
+ count for grid        2:         109240          cutoff [a.u.]           50.00
+ count for grid        3:          79882          cutoff [a.u.]           16.67
+ count for grid        4:          29153          cutoff [a.u.]            5.56
+ total gridlevel count  :         431377
+
+ -------------------------------------------------------------------------------
+ -                                                                             -
+ -  BSSE CALCULATION         FRAGMENT CONF: 11        FRAGMENT SUBCONF: 01     -
+ -                           CHARGE =     0           MULTIPLICITY =     1     -
+ -                                                                             -
+ -                 ATOM INDEX                              ATOM NAME           -
+ -                 ----------                              ---------           -
+ -                      1                                   Zn_ghost           -
+ -                      2                                   Zn_ghost           -
+ -                      3                                   Zn_ghost           -
+ -                      4                                   Zn_ghost           -
+ -                      5                                   Zn_ghost           -
+ -                      6                                   Zn_ghost           -
+ -                      7                                   H_ghost            -
+ -                      8                                   H_ghost            -
+ -                      9                                   H_ghost            -
+ -                     10                                   H_ghost            -
+ -                     11                                   H_ghost            -
+ -                     12                                   H_ghost            -
+ -                     13                                   C_ghost            -
+ -                     14                                   C_ghost            -
+ -                     15                                   C_ghost            -
+ -                     16                                   C_ghost            -
+ -                     17                                   C_ghost            -
+ -                     18                                   C_ghost            -
+ -                     19                                   C_ghost            -
+ -                     20                                   C_ghost            -
+ -                     21                                   C_ghost            -
+ -                     22                                   C_ghost            -
+ -                     23                                   C_ghost            -
+ -                     24                                   C_ghost            -
+ -                     25                                   C_ghost            -
+ -                     26                                   C_ghost            -
+ -                     27                                   C_ghost            -
+ -                     28                                   C_ghost            -
+ -                     29                                   C_ghost            -
+ -                     30                                   C_ghost            -
+ -                     31                                   C_ghost            -
+ -                     32                                   C_ghost            -
+ -                     33                                   C_ghost            -
+ -                     34                                   C_ghost            -
+ -                     35                                   C_ghost            -
+ -                     36                                   C_ghost            -
+ -                     37                                   O_ghost            -
+ -                     38                                   O_ghost            -
+ -                     39                                   O_ghost            -
+ -                     40                                   O_ghost            -
+ -                     41                                   O_ghost            -
+ -                     42                                   O_ghost            -
+ -                     43                                   O_ghost            -
+ -                     44                                   O_ghost            -
+ -                     45                                   O_ghost            -
+ -                     46                                   O_ghost            -
+ -                     47                                   O_ghost            -
+ -                     48                                   O_ghost            -
+ -                     49                                   O_ghost            -
+ -                     50                                   O_ghost            -
+ -                     51                                   O_ghost            -
+ -                     52                                   O_ghost            -
+ -                     53                                   O_ghost            -
+ -                     54                                   O_ghost            -
+ -                     55                                   C                  -
+ -                     56                                   O                  -
+ -                     57                                   O                  -
+ -------------------------------------------------------------------------------
+
+ CELL| Volume [angstrom^3]:                                             1375.527
+ CELL| Vector a [angstrom]:       6.917     0.000    -1.071    |a| =       6.999
+ CELL| Vector b [angstrom]:      -3.459    13.046    -7.086    |b| =      15.244
+ CELL| Vector c [angstrom]:       0.000     0.000    15.244    |c| =      15.244
+ CELL| Angle (b,c), alpha [degree]:                                      117.699
+ CELL| Angle (a,c), beta  [degree]:                                       98.805
+ CELL| Angle (a,b), gamma [degree]:                                       98.807
+ CELL| Numerically orthorhombic:                                              NO
+
+ CELL_REF| Volume [angstrom^3]:                                         1375.527
+ CELL_REF| Vector a [angstrom     6.917     0.000    -1.071    |a| =       6.999
+ CELL_REF| Vector b [angstrom    -3.459    13.046    -7.086    |b| =      15.244
+ CELL_REF| Vector c [angstrom     0.000     0.000    15.244    |c| =      15.244
+ CELL_REF| Angle (b,c), alpha [degree]:                                  117.699
+ CELL_REF| Angle (a,c), beta  [degree]:                                   98.805
+ CELL_REF| Angle (a,b), gamma [degree]:                                   98.807
+ CELL_REF| Numerically orthorhombic:                                          NO
+
+ *******************************************************************************
+ *******************************************************************************
+ **                                                                           **
+ **     #####                         ##              ##                      **
+ **    ##   ##            ##          ##              ##                      **
+ **   ##     ##                       ##            ######                    **
+ **   ##     ##  ##   ##  ##   #####  ##  ##   ####   ##    #####    #####    **
+ **   ##     ##  ##   ##  ##  ##      ## ##   ##      ##   ##   ##  ##   ##   **
+ **   ##  ## ##  ##   ##  ##  ##      ####     ###    ##   ######   ######    **
+ **    ##  ###   ##   ##  ##  ##      ## ##      ##   ##   ##       ##        **
+ **     #######   #####   ##   #####  ##  ##  ####    ##    #####   ##        **
+ **           ##                                                    ##        **
+ **                                                                           **
+ **                                                ... make the atoms dance   **
+ **                                                                           **
+ **            Copyright (C) by CP2K developers group (2000 - 2017)           **
+ **                                                                           **
+ *******************************************************************************
+
+ DFT| Spin restricted Kohn-Sham (RKS) calculation                            RKS
+ DFT| Multiplicity                                                             1
+ DFT| Number of spin states                                                    1
+ DFT| Charge                                                                   0
+ DFT| Self-interaction correction (SIC)                                       NO
+ DFT| Cutoffs: density                                              1.000000E-10
+ DFT|          gradient                                             1.000000E-10
+ DFT|          tau                                                  1.000000E-10
+ DFT|          cutoff_smoothing_range                               0.000000E+00
+ DFT| XC density smoothing                                                  NONE
+ DFT| XC derivatives                                                          PW
+ FUNCTIONAL| ROUTINE=NEW
+ FUNCTIONAL| PBE:
+ FUNCTIONAL| J.P.Perdew, K.Burke, M.Ernzerhof, Phys. Rev. Letter, vol. 77, n 18,
+ FUNCTIONAL|  pp. 3865-3868, (1996){spin unpolarized}                           
+ vdW POTENTIAL|                                                   Pair Potential
+ vdW POTENTIAL|          DFT-D3 (Version 3.1)
+ vdW POTENTIAL|          Potential Form: S. Grimme et al, JCP 132: 154104 (2010)
+ vdW POTENTIAL|          BJ Damping: S. Grimme et al, JCC 32: 1456 (2011)
+ vdW POTENTIAL|          Cutoff Radius [Bohr]:                             20.00
+ vdW POTENTIAL|          s6 Scaling Factor:                               1.0000
+ vdW POTENTIAL|          a1 Damping Factor:                               0.4289
+ vdW POTENTIAL|          s8 Scaling Factor:                               0.7875
+ vdW POTENTIAL|          a2 Damping Factor:                               4.4407
+ vdW POTENTIAL|          Cutoff for CN calculation:                   0.1000E-05
+
+ QS| Method:                                                                 GPW
+ QS| Density plane wave grid type                        NON-SPHERICAL FULLSPACE
+ QS| Number of grid levels:                                                    4
+ QS| Density cutoff [a.u.]:                                                150.0
+ QS| Multi grid cutoff [a.u.]: 1) grid level                               150.0
+ QS|                           2) grid level                                50.0
+ QS|                           3) grid level                                16.7
+ QS|                           4) grid level                                 5.6
+ QS| Grid level progression factor:                                          3.0
+ QS| Relative density cutoff [a.u.]:                                        15.0
+ QS| Consistent realspace mapping and integration 
+ QS| Interaction thresholds: eps_pgf_orb:                                1.0E-05
+ QS|                         eps_filter_matrix:                          0.0E+00
+ QS|                         eps_core_charge:                            1.0E-12
+ QS|                         eps_rho_gspace:                             1.0E-10
+ QS|                         eps_rho_rspace:                             1.0E-10
+ QS|                         eps_gvg_rspace:                             1.0E-05
+ QS|                         eps_ppl:                                    1.0E-02
+ QS|                         eps_ppnl:                                   1.0E-07
+
+
+ ATOMIC KIND INFORMATION
+
+  1. Atomic kind: Zn_ghost                              Number of atoms:       6
+
+     Orbital Basis Set                                    DZVP-MOLOPT-SR-GTH-q12
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               7
+       Number of primitive Cartesian functions:                                6
+       Number of Cartesian basis functions:                                   30
+       Number of spherical basis functions:                                   25
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                6.400813       0.070678
+                                                         3.167793      -0.182901
+                                                         1.341704       0.275787
+                                                         0.545418       0.070077
+                                                         0.222222      -0.163015
+                                                         0.079830      -0.058340
+
+                          1       2    3s                6.400813       0.159300
+                                                         3.167793      -0.240359
+                                                         1.341704      -0.028572
+                                                         0.545418      -0.590243
+                                                         0.222222       0.705234
+                                                         0.079830      -0.232595
+
+                          1       3    3px               6.400813       0.044197
+                                                         3.167793      -0.065115
+                                                         1.341704       0.233173
+                                                         0.545418      -0.041743
+                                                         0.222222      -0.119659
+                                                         0.079830      -0.031199
+                          1       3    3py               6.400813       0.044197
+                                                         3.167793      -0.065115
+                                                         1.341704       0.233173
+                                                         0.545418      -0.041743
+                                                         0.222222      -0.119659
+                                                         0.079830      -0.031199
+                          1       3    3pz               6.400813       0.044197
+                                                         3.167793      -0.065115
+                                                         1.341704       0.233173
+                                                         0.545418      -0.041743
+                                                         0.222222      -0.119659
+                                                         0.079830      -0.031199
+
+                          1       4    4px               6.400813       0.240176
+                                                         3.167793      -0.408028
+                                                         1.341704      -0.147214
+                                                         0.545418      -0.102288
+                                                         0.222222       0.357755
+                                                         0.079830      -0.080257
+                          1       4    4py               6.400813       0.240176
+                                                         3.167793      -0.408028
+                                                         1.341704      -0.147214
+                                                         0.545418      -0.102288
+                                                         0.222222       0.357755
+                                                         0.079830      -0.080257
+                          1       4    4pz               6.400813       0.240176
+                                                         3.167793      -0.408028
+                                                         1.341704      -0.147214
+                                                         0.545418      -0.102288
+                                                         0.222222       0.357755
+                                                         0.079830      -0.080257
+
+                          1       5    4dx2              6.400813      12.052935
+                                                         3.167793       4.421864
+                                                         1.341704       0.893324
+                                                         0.545418       0.127232
+                                                         0.222222       0.011466
+                                                         0.079830       0.000178
+                          1       5    4dxy              6.400813      20.876296
+                                                         3.167793       7.658893
+                                                         1.341704       1.547283
+                                                         0.545418       0.220373
+                                                         0.222222       0.019859
+                                                         0.079830       0.000308
+                          1       5    4dxz              6.400813      20.876296
+                                                         3.167793       7.658893
+                                                         1.341704       1.547283
+                                                         0.545418       0.220373
+                                                         0.222222       0.019859
+                                                         0.079830       0.000308
+                          1       5    4dy2              6.400813      12.052935
+                                                         3.167793       4.421864
+                                                         1.341704       0.893324
+                                                         0.545418       0.127232
+                                                         0.222222       0.011466
+                                                         0.079830       0.000178
+                          1       5    4dyz              6.400813      20.876296
+                                                         3.167793       7.658893
+                                                         1.341704       1.547283
+                                                         0.545418       0.220373
+                                                         0.222222       0.019859
+                                                         0.079830       0.000308
+                          1       5    4dz2              6.400813      12.052935
+                                                         3.167793       4.421864
+                                                         1.341704       0.893324
+                                                         0.545418       0.127232
+                                                         0.222222       0.011466
+                                                         0.079830       0.000178
+
+                          1       6    5dx2              6.400813      -3.077244
+                                                         3.167793      -1.397438
+                                                         1.341704      -0.501565
+                                                         0.545418       0.120936
+                                                         0.222222       0.032489
+                                                         0.079830       0.013923
+                          1       6    5dxy              6.400813      -5.329943
+                                                         3.167793      -2.420434
+                                                         1.341704      -0.868735
+                                                         0.545418       0.209468
+                                                         0.222222       0.056272
+                                                         0.079830       0.024116
+                          1       6    5dxz              6.400813      -5.329943
+                                                         3.167793      -2.420434
+                                                         1.341704      -0.868735
+                                                         0.545418       0.209468
+                                                         0.222222       0.056272
+                                                         0.079830       0.024116
+                          1       6    5dy2              6.400813      -3.077244
+                                                         3.167793      -1.397438
+                                                         1.341704      -0.501565
+                                                         0.545418       0.120936
+                                                         0.222222       0.032489
+                                                         0.079830       0.013923
+                          1       6    5dyz              6.400813      -5.329943
+                                                         3.167793      -2.420434
+                                                         1.341704      -0.868735
+                                                         0.545418       0.209468
+                                                         0.222222       0.056272
+                                                         0.079830       0.024116
+                          1       6    5dz2              6.400813      -3.077244
+                                                         3.167793      -1.397438
+                                                         1.341704      -0.501565
+                                                         0.545418       0.120936
+                                                         0.222222       0.032489
+                                                         0.079830       0.013923
+
+                          1       7    5fx3              6.400813      -0.041001
+                                                         3.167793       0.016340
+                                                         1.341704       0.068339
+                                                         0.545418       0.147998
+                                                         0.222222       0.008656
+                                                         0.079830       0.003475
+                          1       7    5fx2y             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fx2z             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fxy2             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fxyz             6.400813      -0.158795
+                                                         3.167793       0.063286
+                                                         1.341704       0.264674
+                                                         0.545418       0.573193
+                                                         0.222222       0.033523
+                                                         0.079830       0.013460
+                          1       7    5fxz2             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fy3              6.400813      -0.041001
+                                                         3.167793       0.016340
+                                                         1.341704       0.068339
+                                                         0.545418       0.147998
+                                                         0.222222       0.008656
+                                                         0.079830       0.003475
+                          1       7    5fy2z             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fyz2             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fz3              6.400813      -0.041001
+                                                         3.167793       0.016340
+                                                         1.341704       0.068339
+                                                         0.545418       0.147998
+                                                         0.222222       0.008656
+                                                         0.079830       0.003475
+
+     The atoms of this atomic kind are GHOST atoms!
+
+  2. Atomic kind: H_ghost                               Number of atoms:       6
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q1
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               3
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                    5
+       Number of spherical basis functions:                                    5
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s               10.068468      -0.133023
+                                                         2.680223      -0.177618
+                                                         0.791502      -0.258419
+                                                         0.239116      -0.107525
+                                                         0.082193      -0.014019
+
+                          1       2    3s               10.068468       0.344673
+                                                         2.680223       1.819821
+                                                         0.791502      -0.999069
+                                                         0.239116       0.017430
+                                                         0.082193       0.082660
+
+                          1       3    3px              10.068468       0.155326
+                                                         2.680223       0.367157
+                                                         0.791502       0.311480
+                                                         0.239116       0.080105
+                                                         0.082193       0.033440
+                          1       3    3py              10.068468       0.155326
+                                                         2.680223       0.367157
+                                                         0.791502       0.311480
+                                                         0.239116       0.080105
+                                                         0.082193       0.033440
+                          1       3    3pz              10.068468       0.155326
+                                                         2.680223       0.367157
+                                                         0.791502       0.311480
+                                                         0.239116       0.080105
+                                                         0.082193       0.033440
+
+     The atoms of this atomic kind are GHOST atoms!
+
+  3. Atomic kind: C_ghost                               Number of atoms:      24
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q4
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                5.605331       0.322515
+                                                         2.113016       0.213043
+                                                         0.769911      -0.209686
+                                                         0.348157      -0.219794
+                                                         0.128212      -0.022789
+
+                          1       2    3s                5.605331       0.552234
+                                                         2.113016       0.082072
+                                                         0.769911       0.007843
+                                                         0.348157       0.136893
+                                                         0.128212       0.074283
+
+                          1       3    3px               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+                          1       3    3py               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+                          1       3    3pz               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+
+                          1       4    4px               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+                          1       4    4py               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+                          1       4    4pz               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+
+                          1       5    4dx2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+                          1       5    4dxy              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dxz              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dy2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+                          1       5    4dyz              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dz2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+
+     The atoms of this atomic kind are GHOST atoms!
+
+  4. Atomic kind: O_ghost                               Number of atoms:      18
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q6
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s               10.389228       0.396646
+                                                         3.849621       0.208811
+                                                         1.388401      -0.301641
+                                                         0.496955      -0.274061
+                                                         0.162492      -0.033677
+
+                          1       2    3s               10.389228       0.303673
+                                                         3.849621       0.240943
+                                                         1.388401      -0.313066
+                                                         0.496955      -0.043055
+                                                         0.162492       0.213991
+
+                          1       3    3px              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+                          1       3    3py              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+                          1       3    3pz              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+
+                          1       4    4px              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+                          1       4    4py              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+                          1       4    4pz              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+
+                          1       5    4dx2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+                          1       5    4dxy             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dxz             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dy2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+                          1       5    4dyz             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dz2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+
+     The atoms of this atomic kind are GHOST atoms!
+
+  5. Atomic kind: C                                     Number of atoms:       1
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q4
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                5.605331       0.322515
+                                                         2.113016       0.213043
+                                                         0.769911      -0.209686
+                                                         0.348157      -0.219794
+                                                         0.128212      -0.022789
+
+                          1       2    3s                5.605331       0.552234
+                                                         2.113016       0.082072
+                                                         0.769911       0.007843
+                                                         0.348157       0.136893
+                                                         0.128212       0.074283
+
+                          1       3    3px               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+                          1       3    3py               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+                          1       3    3pz               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+
+                          1       4    4px               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+                          1       4    4py               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+                          1       4    4pz               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+
+                          1       5    4dx2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+                          1       5    4dxy              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dxz              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dy2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+                          1       5    4dyz              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dz2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+
+     GTH Potential information for                                    GTH-PBE-q4
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               4.364419
+       Electronic configuration (s p d ...):                               2   2
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.338471   -8.803674    1.339211
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.302576    9.622487
+                   1    0.291507
+
+  6. Atomic kind: O                                     Number of atoms:       2
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q6
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s               10.389228       0.396646
+                                                         3.849621       0.208811
+                                                         1.388401      -0.301641
+                                                         0.496955      -0.274061
+                                                         0.162492      -0.033677
+
+                          1       2    3s               10.389228       0.303673
+                                                         3.849621       0.240943
+                                                         1.388401      -0.313066
+                                                         0.496955      -0.043055
+                                                         0.162492       0.213991
+
+                          1       3    3px              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+                          1       3    3py              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+                          1       3    3pz              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+
+                          1       4    4px              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+                          1       4    4py              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+                          1       4    4pz              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+
+                          1       5    4dx2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+                          1       5    4dxy             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dxz             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dy2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+                          1       5    4dyz             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dz2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+
+     GTH Potential information for                                    GTH-PBE-q6
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               8.360253
+       Electronic configuration (s p d ...):                               2   4
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.244554  -16.667215    2.487311
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.220956   18.337458
+                   1    0.211332
+
+
+ MOLECULE KIND INFORMATION
+
+
+ All atoms are their own molecule, skipping detailed information
+
+
+ TOTAL NUMBERS AND MAXIMUM NUMBERS
+
+  Total number of            - Atomic kinds:                                   6
+                             - Atoms:                                         57
+                             - Shell sets:                                    57
+                             - Shells:                                       285
+                             - Primitive Cartesian functions:                291
+                             - Cartesian basis functions:                    840
+                             - Spherical basis functions:                    765
+
+  Maximum angular momentum of- Orbital basis functions:                        3
+                             - Local part of the GTH pseudopotential:          2
+                             - Non-local part of the GTH pseudopotential:      0
+
+
+ MODULE QUICKSTEP:  ATOMIC COORDINATES IN angstrom
+
+  Atom  Kind  Element       X           Y           Z          Z(eff)       Mass
+
+       1     1 Zn  30   -0.383625    4.293611    6.600223      0.00      65.3800
+       2     1 Zn  30    2.159815    5.301947    7.779863      0.00      65.3800
+       3     1 Zn  30    4.480115    3.451223    7.517364      0.00      65.3800
+       4     1 Zn  30    3.841016    8.753170    0.486751      0.00      65.3800
+       5     1 Zn  30    1.297611    7.744704   -0.692817      0.00      65.3800
+       6     1 Zn  30   -1.022759    9.595428   -0.430460      0.00      65.3800
+       7     2 H    1    4.482787    0.326675    6.269586      0.00       1.0079
+       8     2 H    1   -0.512588    6.923320    4.505711      0.00       1.0079
+       9     2 H    1    2.859209    5.797047   11.033385      0.00       1.0079
+      10     2 H    1   -1.025431   12.719976    0.817165      0.00       1.0079
+      11     2 H    1    3.969979    6.123462    2.581264      0.00       1.0079
+      12     2 H    1    0.598147    7.249603   -3.946328      0.00       1.0079
+      13     3 C    6    1.847192    2.234671    7.703263      0.00      12.0107
+      14     3 C    6    0.863924    1.115183    7.649961      0.00      12.0107
+      15     3 C    6    6.377042    1.321703    6.419893      0.00      12.0107
+      16     3 C    6    5.556141    0.189038    6.393652      0.00      12.0107
+      17     3 C    6    3.788779    5.091774    4.998794      0.00      12.0107
+      18     3 C    6    2.703758    5.827445    4.288289      0.00      12.0107
+      19     3 C    6    1.413046    6.046098    4.857577      0.00      12.0107
+      20     3 C    6    0.476664    6.743674    4.086548      0.00      12.0107
+      21     3 C    6   -0.261767    5.720467    9.332098      0.00      12.0107
+      22     3 C    6   -1.050040    6.104414   10.537978      0.00      12.0107
+      23     3 C    6    4.520985    5.679110    9.682078      0.00      12.0107
+      24     3 C    6    3.884975    6.114329   10.849971      0.00      12.0107
+      25     3 C    6    1.610199   10.812110   -0.616593      0.00      12.0107
+      26     3 C    6    2.593398   11.931598   -0.563280      0.00      12.0107
+      27     3 C    6   -2.919721   11.725078    0.666788      0.00      12.0107
+      28     3 C    6   -2.098784   12.857612    0.693100      0.00      12.0107
+      29     3 C    6   -0.331423    7.955138    2.088110      0.00      12.0107
+      30     3 C    6    0.753633    7.219336    2.798686      0.00      12.0107
+      31     3 C    6    2.044379    7.000814    2.229468      0.00      12.0107
+      32     3 C    6    2.980692    6.303237    3.000509      0.00      12.0107
+      33     3 C    6    3.719192    7.326184   -2.244900      0.00      12.0107
+      34     3 C    6    4.507397    6.942237   -3.450922      0.00      12.0107
+      35     3 C    6   -1.063664    7.367410   -2.595245      0.00      12.0107
+      36     3 C    6   -0.427584    6.932191   -3.762996      0.00      12.0107
+      37     4 O    8    1.377982    3.429566    7.648309      0.00      15.9994
+      38     4 O    8    3.094194    1.983664    7.794712      0.00      15.9994
+      39     4 O    8    5.787621    2.541908    6.286912      0.00      15.9994
+      40     4 O    8    3.507212    4.603457    6.153450      0.00      15.9994
+      41     4 O    8    4.938109    4.973837    4.458421      0.00      15.9994
+      42     4 O    8    1.036370    5.627970    6.097393      0.00      15.9994
+      43     4 O    8   -0.860163    5.013497    8.441294      0.00      15.9994
+      44     4 O    8    0.954027    6.089542    9.221463      0.00      15.9994
+      45     4 O    8    3.820924    4.876904    8.833239      0.00      15.9994
+      46     4 O    8    2.079374    9.617084   -0.561405      0.00      15.9994
+      47     4 O    8    0.363162   11.062987   -0.707808      0.00      15.9994
+      48     4 O    8   -2.330264   10.504743    0.799992      0.00      15.9994
+      49     4 O    8   -0.049786    8.443194    0.933596      0.00      15.9994
+      50     4 O    8   -1.480753    8.073075    2.628483      0.00      15.9994
+      51     4 O    8    2.420986    7.418942    0.989510      0.00      15.9994
+      52     4 O    8    4.317519    8.032893   -1.354390      0.00      15.9994
+      53     4 O    8    2.503330    6.957109   -2.134407      0.00      15.9994
+      54     4 O    8   -0.363568    8.169486   -1.746335      0.00      15.9994
+      55     5 C    6    5.922650    0.971024    9.644414      4.00      12.0107
+      56     6 O    8    5.627701    2.095563    9.433385      6.00      15.9994
+      57     6 O    8    2.756503   12.905778    2.804537      6.00      15.9994
+
+
+
+
+ SCF PARAMETERS         Density guess:                                    ATOMIC
+                        --------------------------------------------------------
+                        max_scf:                                              50
+                        max_scf_history:                                       0
+                        max_diis:                                              4
+                        --------------------------------------------------------
+                        eps_scf:                                        1.00E-04
+                        eps_scf_history:                                0.00E+00
+                        eps_diis:                                       1.00E-01
+                        eps_eigval:                                     1.00E-05
+                        --------------------------------------------------------
+                        level_shift [a.u.]:                                 0.00
+                        --------------------------------------------------------
+                        Outer loop SCF in use 
+                        No variables optimised in outer loop
+                        eps_scf                                         1.00E-04
+                        max_scf                                                5
+                        No outer loop optimization
+                        step_size                                       5.00E-01
+
+ PW_GRID| Information for grid number                                         17
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                    150.0
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -37      37                Points:          75
+ PW_GRID|   Bounds   2            -80      79                Points:         160
+ PW_GRID|   Bounds   3            -80      79                Points:         160
+ PW_GRID| Volume element (a.u.^3)  0.4835E-02     Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                           480000.0      480000      480000
+ PW_GRID|   G-Rays                                6400.0        6400        6400
+ PW_GRID|   Real Space Points                   480000.0      486400      460800
+
+ PW_GRID| Information for grid number                                         18
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                     50.0
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -22      22                Points:          45
+ PW_GRID|   Bounds   2            -48      47                Points:          96
+ PW_GRID|   Bounds   3            -48      47                Points:          96
+ PW_GRID| Volume element (a.u.^3)  0.2238E-01     Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                           103680.0      103725      103635
+ PW_GRID|   G-Rays                                2304.0        2305        2303
+ PW_GRID|   Real Space Points                   103680.0      110592      101376
+
+ PW_GRID| Information for grid number                                         19
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                     16.7
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -12      12                Points:          25
+ PW_GRID|   Bounds   2            -27      26                Points:          54
+ PW_GRID|   Bounds   3            -27      26                Points:          54
+ PW_GRID| Volume element (a.u.^3)  0.1273         Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                            18225.0       18225       18225
+ PW_GRID|   G-Rays                                 729.0         729         729
+ PW_GRID|   Real Space Points                    18225.0       20412       17496
+
+ PW_GRID| Information for grid number                                         20
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                      5.6
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1             -7       7                Points:          15
+ PW_GRID|   Bounds   2            -16      15                Points:          32
+ PW_GRID|   Bounds   3            -16      15                Points:          32
+ PW_GRID| Volume element (a.u.^3)  0.6043         Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                             3840.0        3855        3825
+ PW_GRID|   G-Rays                                 256.0         257         255
+ PW_GRID|   Real Space Points                     3840.0        4096        3072
+
+ POISSON| Solver                                                        PERIODIC
+ POISSON| Periodicity                                                        XYZ
+
+ RS_GRID| Information for grid number                                         17
+ RS_GRID|   Bounds   1            -37      37                Points:          75
+ RS_GRID|   Bounds   2            -80      79                Points:         160
+ RS_GRID|   Bounds   3            -80      79                Points:         160
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                         18
+ RS_GRID|   Bounds   1            -22      22                Points:          45
+ RS_GRID|   Bounds   2            -48      47                Points:          96
+ RS_GRID|   Bounds   3            -48      47                Points:          96
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                         19
+ RS_GRID|   Bounds   1            -12      12                Points:          25
+ RS_GRID|   Bounds   2            -27      26                Points:          54
+ RS_GRID|   Bounds   3            -27      26                Points:          54
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                         20
+ RS_GRID|   Bounds   1             -7       7                Points:          15
+ RS_GRID|   Bounds   2            -16      15                Points:          32
+ RS_GRID|   Bounds   3            -16      15                Points:          32
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ DISTRIBUTION OF THE PARTICLES (ROWS)
+              Process row      Number of particles         Number of matrix rows
+                        0                       29                            -1
+                        1                       28                            -1
+                      Sum                       57                            -1
+
+ DISTRIBUTION OF THE PARTICLES (COLUMNS)
+              Process col      Number of particles      Number of matrix columns
+                        0                       29                            -1
+                        1                       28                            -1
+                      Sum                       57                            -1
+
+ DISTRIBUTION OF THE NEIGHBOR LISTS
+              Total number of particle pairs:                               6196
+              Total number of matrix elements:                           1216356
+              Average number of particle pairs:                             1549
+              Maximum number of particle pairs:                             1690
+              Average number of matrix element:                           304089
+              Maximum number of matrix elements:                          314098
+
+
+ DISTRIBUTION OF THE OVERLAP MATRIX
+              Number  of non-zero blocks:                                   1653
+              Percentage non-zero blocks:                                 100.00
+              Average number of blocks per CPU:                              414
+              Maximum number of blocks per CPU:                              435
+              Average number of matrix elements per CPU:                   74602
+              Maximum number of matrix elements per CPU:                   76644
+
+ Number of electrons:                                                         16
+ Number of occupied orbitals:                                                  8
+ Number of molecular orbitals:                                                 8
+
+ Number of orbital functions:                                                765
+ Number of independent orbital functions:                                    765
+
+ Extrapolation method: initial_guess
+
+ Atomic guess: The first density matrix is obtained in terms of atomic orbitals
+               and electronic configurations assigned to each atomic kind
+
+ Guess for atomic kind: Zn_ghost
+
+ Electronic structure
+    Total number of core electrons                                          0.00
+    Total number of valence electrons                                       0.00
+    Total number of electrons                                               0.00
+    Multiplicity                                                   not specified
+    S
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1         0.00000                       0.000000000000
+
+ Energy components [Hartree]           Total Energy ::            0.000000000000
+                                        Band Energy ::            0.000000000000
+                                     Kinetic Energy ::            0.000000000000
+                                   Potential Energy ::            0.000000000000
+                                        Core Energy ::            0.000000000000
+                                     Coulomb Energy ::            0.000000000000
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+
+ Total Electron Density at R=0:                                         0.000000
+
+ Guess for atomic kind: H_ghost
+
+ Electronic structure
+    Total number of core electrons                                          0.00
+    Total number of valence electrons                                       0.00
+    Total number of electrons                                               0.00
+    Multiplicity                                                   not specified
+    S
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1         0.00000                       0.000000000000
+
+ Energy components [Hartree]           Total Energy ::            0.000000000000
+                                        Band Energy ::            0.000000000000
+                                     Kinetic Energy ::            0.000000000000
+                                   Potential Energy ::            0.000000000000
+                                        Core Energy ::            0.000000000000
+                                     Coulomb Energy ::            0.000000000000
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+
+ Total Electron Density at R=0:                                         0.000000
+
+ Guess for atomic kind: C_ghost
+
+ Electronic structure
+    Total number of core electrons                                          0.00
+    Total number of valence electrons                                       0.00
+    Total number of electrons                                               0.00
+    Multiplicity                                                   not specified
+    S
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1         0.00000                       0.000000000000
+
+ Energy components [Hartree]           Total Energy ::            0.000000000000
+                                        Band Energy ::            0.000000000000
+                                     Kinetic Energy ::            0.000000000000
+                                   Potential Energy ::            0.000000000000
+                                        Core Energy ::            0.000000000000
+                                     Coulomb Energy ::            0.000000000000
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+
+ Total Electron Density at R=0:                                         0.000000
+
+ Guess for atomic kind: O_ghost
+
+ Electronic structure
+    Total number of core electrons                                          0.00
+    Total number of valence electrons                                       0.00
+    Total number of electrons                                               0.00
+    Multiplicity                                                   not specified
+    S
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1         0.00000                       0.000000000000
+
+ Energy components [Hartree]           Total Energy ::            0.000000000000
+                                        Band Energy ::            0.000000000000
+                                     Kinetic Energy ::            0.000000000000
+                                   Potential Energy ::            0.000000000000
+                                        Core Energy ::            0.000000000000
+                                     Coulomb Energy ::            0.000000000000
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+
+ Total Electron Density at R=0:                                         0.000000
+
+ Guess for atomic kind: C
+
+ Electronic structure
+    Total number of core electrons                                          2.00
+    Total number of valence electrons                                       4.00
+    Total number of electrons                                               6.00
+    Multiplicity                                                   not specified
+    S   [  2.00] 2.00
+    P      2.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1        0.457038                      -5.151105664215
+                          2        0.157450                      -5.235617431356
+                          3        0.130137E-02                  -5.246564342251
+                          4        0.531061E-03                  -5.246565033610
+                          5        0.605965E-04                  -5.246565167704
+                          6        0.323545E-04                  -5.246565168968
+                          7        0.365472E-07                  -5.246565169473
+
+ Energy components [Hartree]           Total Energy ::           -5.246565169473
+                                        Band Energy ::           -1.058732656762
+                                     Kinetic Energy ::            3.518928154187
+                                   Potential Energy ::           -8.765493323660
+                                      Virial (-V/T) ::            2.490955467002
+                                        Core Energy ::           -8.429377161979
+                                          XC Energy ::           -1.450183339326
+                                     Coulomb Energy ::            4.632995331832
+                       Total Pseudopotential Energy ::          -11.978048785149
+                       Local Pseudopotential Energy ::          -12.816738149676
+                    Nonlocal Pseudopotential Energy ::            0.838689364526
+                                        Confinement ::            0.297434689834
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.410911          -11.181458
+
+                       1     1          2.000      -0.118455           -3.223332
+
+
+ Total Electron Density at R=0:                                         0.001337
+
+ Guess for atomic kind: O
+
+ Electronic structure
+    Total number of core electrons                                          2.00
+    Total number of valence electrons                                       6.00
+    Total number of electrons                                               8.00
+    Multiplicity                                                   not specified
+    S   [  2.00] 2.00
+    P      4.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1         1.67054                     -14.836051221656
+                          2         2.12470                     -14.897900780399
+                          3        0.100150                     -15.654295189160
+                          4        0.189307E-01                 -15.655828842238
+                          5        0.464435E-02                 -15.655882433232
+                          6        0.259395E-02                 -15.655884790195
+                          7        0.516014E-04                 -15.655885857622
+                          8        0.157374E-05                 -15.655885858066
+                          9        0.783512E-06                 -15.655885858066
+
+ Energy components [Hartree]           Total Energy ::          -15.655885858066
+                                        Band Energy ::           -2.983129541149
+                                     Kinetic Energy ::           11.754767937471
+                                   Potential Energy ::          -27.410653795537
+                                      Virial (-V/T) ::            2.331875366774
+                                        Core Energy ::          -26.153524299614
+                                          XC Energy ::           -3.157392735430
+                                     Coulomb Energy ::           13.655031176977
+                       Total Pseudopotential Energy ::          -37.943031004163
+                       Local Pseudopotential Energy ::          -39.220423834999
+                    Nonlocal Pseudopotential Energy ::            1.277392830837
+                                        Confinement ::            0.347387670777
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.861523          -23.443221
+
+                       1     1          4.000      -0.315021           -8.572160
+
+
+ Total Electron Density at R=0:                                         0.000093
+ Re-scaling the density matrix to get the right number of electrons
+                  # Electrons              Trace(P)               Scaling factor
+                           16                16.000                        1.000
+
+
+ SCF WAVEFUNCTION OPTIMIZATION
+
+  ----------------------------------- OT ---------------------------------------
+  Minimizer      : DIIS                : direct inversion
+                                         in the iterative subspace
+                                         using   7 DIIS vectors
+                                         safer DIIS on
+  Preconditioner : FULL_ALL            : diagonalization, state selective
+  Precond_solver : DEFAULT
+  stepsize       :    0.15000000                  energy_gap     :    0.08000000
+  eps_taylor     :   0.10000E-15                  max_taylor     :             4
+  ----------------------------------- OT ---------------------------------------
+
+  Step     Update method      Time    Convergence         Total energy    Change
+  ------------------------------------------------------------------------------
+     1 OT DIIS     0.15E+00    1.6     0.05070891       -36.3917831137 -3.64E+01
+     2 OT DIIS     0.15E+00    2.3     0.05502110       -37.3860580384 -9.94E-01
+     3 OT DIIS     0.15E+00    2.3     0.06276350       -37.2519427016  1.34E-01
+     4 OT DIIS     0.15E+00    2.3     0.02151099       -37.6804074111 -4.28E-01
+     5 OT DIIS     0.15E+00    2.3     0.01187834       -37.7370380292 -5.66E-02
+     6 OT DIIS     0.15E+00    2.3     0.00684397       -37.7545416825 -1.75E-02
+     7 OT DIIS     0.15E+00    2.3     0.00289847       -37.7603525855 -5.81E-03
+     8 OT DIIS     0.15E+00    2.3     0.00139345       -37.7622767510 -1.92E-03
+     9 OT DIIS     0.15E+00    2.3     0.00063067       -37.7625092721 -2.33E-04
+    10 OT DIIS     0.15E+00    2.3     0.00027936       -37.7625726349 -6.34E-05
+    11 OT DIIS     0.15E+00    2.3     0.00016936       -37.7625867161 -1.41E-05
+    12 OT DIIS     0.15E+00    2.3     0.00004430       -37.7625902034 -3.49E-06
+
+  *** SCF run converged in    12 steps ***
+
+
+  Electronic density on regular grids:        -15.9999999689        0.0000000311
+  Core density on regular grids:               15.9999999994       -0.0000000006
+  Total charge density on r-space grids:        0.0000000306
+  Total charge density g-space grids:           0.0000000306
+
+  Overlap energy of the core charge distribution:               0.00000208617292
+  Self energy of the core charge distribution:                -96.38742208476295
+  Core Hamiltonian energy:                                     27.67036587276747
+  Hartree energy:                                              39.59929762565963
+  Exchange-correlation energy:                                 -8.64386567330882
+  Dispersion energy:                                           -0.00096802992140
+
+  Total energy:                                               -37.76259020339316
+
+  outer SCF iter =    1 RMS gradient =   0.44E-04 energy =        -37.7625902034
+  outer SCF loop converged in   1 iterations or   12 steps
+
+
+ !-----------------------------------------------------------------------------!
+                     Mulliken Population Analysis
+
+ #  Atom  Element  Kind  Atomic population                           Net charge
+       1     Zn       1          0.000340                             -0.000340
+       2     Zn       1          0.000103                             -0.000103
+       3     Zn       1          0.018372                             -0.018372
+       4     Zn       1          0.000398                             -0.000398
+       5     Zn       1         -0.000005                              0.000005
+       6     Zn       1          0.000038                             -0.000038
+       7     H        2          0.000089                             -0.000089
+       8     H        2          0.000000                             -0.000000
+       9     H        2          0.000010                             -0.000010
+      10     H        2          0.000112                             -0.000112
+      11     H        2         -0.000000                              0.000000
+      12     H        2          0.000001                             -0.000001
+      13     C        3         -0.000160                              0.000160
+      14     C        3          0.000034                             -0.000034
+      15     C        3         -0.000817                              0.000817
+      16     C        3         -0.000087                              0.000087
+      17     C        3         -0.000001                              0.000001
+      18     C        3         -0.000000                              0.000000
+      19     C        3         -0.000000                              0.000000
+      20     C        3         -0.000000                              0.000000
+      21     C        3          0.000077                             -0.000077
+      22     C        3          0.000059                             -0.000059
+      23     C        3          0.000072                             -0.000072
+      24     C        3          0.000009                             -0.000009
+      25     C        3          0.000044                             -0.000044
+      26     C        3         -0.000101                              0.000101
+      27     C        3          0.000092                             -0.000092
+      28     C        3         -0.000039                              0.000039
+      29     C        3          0.000000                             -0.000000
+      30     C        3          0.000000                             -0.000000
+      31     C        3         -0.000000                              0.000000
+      32     C        3         -0.000000                              0.000000
+      33     C        3          0.000000                             -0.000000
+      34     C        3          0.000002                             -0.000002
+      35     C        3          0.000001                             -0.000001
+      36     C        3          0.000007                             -0.000007
+      37     O        4          0.000054                             -0.000054
+      38     O        4         -0.000378                              0.000378
+      39     O        4          0.000462                             -0.000462
+      40     O        4         -0.000004                              0.000004
+      41     O        4         -0.000000                              0.000000
+      42     O        4         -0.000000                              0.000000
+      43     O        4          0.000091                             -0.000091
+      44     O        4          0.000001                             -0.000001
+      45     O        4          0.000071                             -0.000071
+      46     O        4         -0.000008                              0.000008
+      47     O        4          0.000004                             -0.000004
+      48     O        4          0.000007                             -0.000007
+      49     O        4         -0.000001                              0.000001
+      50     O        4         -0.000001                              0.000001
+      51     O        4         -0.000000                              0.000000
+      52     O        4         -0.000000                              0.000000
+      53     O        4         -0.000000                              0.000000
+      54     O        4          0.000000                             -0.000000
+      55     C        5          3.511438                              0.488562
+      56     O        6          6.247159                             -0.247159
+      57     O        6          6.222456                             -0.222456
+ # Total charge                             16.000000                 -0.000000
+
+ !-----------------------------------------------------------------------------!
+  
+  Eigenvalues of the occupied subspace spin            1
+ ---------------------------------------------
+      -1.06535229     -1.02902520     -0.50478847     -0.46199214
+      -0.45898965     -0.45897839     -0.32896387     -0.32894085
+ Fermi Energy [eV] :   -8.950936
+  
+  Lowest Eigenvalues of the unoccupied subspace spin            1
+ -----------------------------------------------------
+  Reached convergence in         1033  iterations 
+      -0.01760834
+  
+ HOMO - LUMO gap [eV] :    8.471789
+
+ -------------------------------------------------------------------------------
+ ----                             MULTIGRID INFO                            ----
+ -------------------------------------------------------------------------------
+ count for grid        1:         213102          cutoff [a.u.]          150.00
+ count for grid        2:         109240          cutoff [a.u.]           50.00
+ count for grid        3:          79882          cutoff [a.u.]           16.67
+ count for grid        4:          29153          cutoff [a.u.]            5.56
+ total gridlevel count  :         431377
+
+ -------------------------------------------------------------------------------
+ -                                                                             -
+ -  BSSE CALCULATION         FRAGMENT CONF: 11        FRAGMENT SUBCONF: 11     -
+ -                           CHARGE =     0           MULTIPLICITY =     1     -
+ -                                                                             -
+ -                 ATOM INDEX                              ATOM NAME           -
+ -                 ----------                              ---------           -
+ -                      1                                   Zn                 -
+ -                      2                                   Zn                 -
+ -                      3                                   Zn                 -
+ -                      4                                   Zn                 -
+ -                      5                                   Zn                 -
+ -                      6                                   Zn                 -
+ -                      7                                   H                  -
+ -                      8                                   H                  -
+ -                      9                                   H                  -
+ -                     10                                   H                  -
+ -                     11                                   H                  -
+ -                     12                                   H                  -
+ -                     13                                   C                  -
+ -                     14                                   C                  -
+ -                     15                                   C                  -
+ -                     16                                   C                  -
+ -                     17                                   C                  -
+ -                     18                                   C                  -
+ -                     19                                   C                  -
+ -                     20                                   C                  -
+ -                     21                                   C                  -
+ -                     22                                   C                  -
+ -                     23                                   C                  -
+ -                     24                                   C                  -
+ -                     25                                   C                  -
+ -                     26                                   C                  -
+ -                     27                                   C                  -
+ -                     28                                   C                  -
+ -                     29                                   C                  -
+ -                     30                                   C                  -
+ -                     31                                   C                  -
+ -                     32                                   C                  -
+ -                     33                                   C                  -
+ -                     34                                   C                  -
+ -                     35                                   C                  -
+ -                     36                                   C                  -
+ -                     37                                   O                  -
+ -                     38                                   O                  -
+ -                     39                                   O                  -
+ -                     40                                   O                  -
+ -                     41                                   O                  -
+ -                     42                                   O                  -
+ -                     43                                   O                  -
+ -                     44                                   O                  -
+ -                     45                                   O                  -
+ -                     46                                   O                  -
+ -                     47                                   O                  -
+ -                     48                                   O                  -
+ -                     49                                   O                  -
+ -                     50                                   O                  -
+ -                     51                                   O                  -
+ -                     52                                   O                  -
+ -                     53                                   O                  -
+ -                     54                                   O                  -
+ -                     55                                   C                  -
+ -                     56                                   O                  -
+ -                     57                                   O                  -
+ -------------------------------------------------------------------------------
+
+ CELL| Volume [angstrom^3]:                                             1375.527
+ CELL| Vector a [angstrom]:       6.917     0.000    -1.071    |a| =       6.999
+ CELL| Vector b [angstrom]:      -3.459    13.046    -7.086    |b| =      15.244
+ CELL| Vector c [angstrom]:       0.000     0.000    15.244    |c| =      15.244
+ CELL| Angle (b,c), alpha [degree]:                                      117.699
+ CELL| Angle (a,c), beta  [degree]:                                       98.805
+ CELL| Angle (a,b), gamma [degree]:                                       98.807
+ CELL| Numerically orthorhombic:                                              NO
+
+ CELL_REF| Volume [angstrom^3]:                                         1375.527
+ CELL_REF| Vector a [angstrom     6.917     0.000    -1.071    |a| =       6.999
+ CELL_REF| Vector b [angstrom    -3.459    13.046    -7.086    |b| =      15.244
+ CELL_REF| Vector c [angstrom     0.000     0.000    15.244    |c| =      15.244
+ CELL_REF| Angle (b,c), alpha [degree]:                                  117.699
+ CELL_REF| Angle (a,c), beta  [degree]:                                   98.805
+ CELL_REF| Angle (a,b), gamma [degree]:                                   98.807
+ CELL_REF| Numerically orthorhombic:                                          NO
+
+ *******************************************************************************
+ *******************************************************************************
+ **                                                                           **
+ **     #####                         ##              ##                      **
+ **    ##   ##            ##          ##              ##                      **
+ **   ##     ##                       ##            ######                    **
+ **   ##     ##  ##   ##  ##   #####  ##  ##   ####   ##    #####    #####    **
+ **   ##     ##  ##   ##  ##  ##      ## ##   ##      ##   ##   ##  ##   ##   **
+ **   ##  ## ##  ##   ##  ##  ##      ####     ###    ##   ######   ######    **
+ **    ##  ###   ##   ##  ##  ##      ## ##      ##   ##   ##       ##        **
+ **     #######   #####   ##   #####  ##  ##  ####    ##    #####   ##        **
+ **           ##                                                    ##        **
+ **                                                                           **
+ **                                                ... make the atoms dance   **
+ **                                                                           **
+ **            Copyright (C) by CP2K developers group (2000 - 2017)           **
+ **                                                                           **
+ *******************************************************************************
+
+ DFT| Spin restricted Kohn-Sham (RKS) calculation                            RKS
+ DFT| Multiplicity                                                             1
+ DFT| Number of spin states                                                    1
+ DFT| Charge                                                                   0
+ DFT| Self-interaction correction (SIC)                                       NO
+ DFT| Cutoffs: density                                              1.000000E-10
+ DFT|          gradient                                             1.000000E-10
+ DFT|          tau                                                  1.000000E-10
+ DFT|          cutoff_smoothing_range                               0.000000E+00
+ DFT| XC density smoothing                                                  NONE
+ DFT| XC derivatives                                                          PW
+ FUNCTIONAL| ROUTINE=NEW
+ FUNCTIONAL| PBE:
+ FUNCTIONAL| J.P.Perdew, K.Burke, M.Ernzerhof, Phys. Rev. Letter, vol. 77, n 18,
+ FUNCTIONAL|  pp. 3865-3868, (1996){spin unpolarized}                           
+ vdW POTENTIAL|                                                   Pair Potential
+ vdW POTENTIAL|          DFT-D3 (Version 3.1)
+ vdW POTENTIAL|          Potential Form: S. Grimme et al, JCP 132: 154104 (2010)
+ vdW POTENTIAL|          BJ Damping: S. Grimme et al, JCC 32: 1456 (2011)
+ vdW POTENTIAL|          Cutoff Radius [Bohr]:                             20.00
+ vdW POTENTIAL|          s6 Scaling Factor:                               1.0000
+ vdW POTENTIAL|          a1 Damping Factor:                               0.4289
+ vdW POTENTIAL|          s8 Scaling Factor:                               0.7875
+ vdW POTENTIAL|          a2 Damping Factor:                               4.4407
+ vdW POTENTIAL|          Cutoff for CN calculation:                   0.1000E-05
+
+ QS| Method:                                                                 GPW
+ QS| Density plane wave grid type                        NON-SPHERICAL FULLSPACE
+ QS| Number of grid levels:                                                    4
+ QS| Density cutoff [a.u.]:                                                150.0
+ QS| Multi grid cutoff [a.u.]: 1) grid level                               150.0
+ QS|                           2) grid level                                50.0
+ QS|                           3) grid level                                16.7
+ QS|                           4) grid level                                 5.6
+ QS| Grid level progression factor:                                          3.0
+ QS| Relative density cutoff [a.u.]:                                        15.0
+ QS| Consistent realspace mapping and integration 
+ QS| Interaction thresholds: eps_pgf_orb:                                1.0E-05
+ QS|                         eps_filter_matrix:                          0.0E+00
+ QS|                         eps_core_charge:                            1.0E-12
+ QS|                         eps_rho_gspace:                             1.0E-10
+ QS|                         eps_rho_rspace:                             1.0E-10
+ QS|                         eps_gvg_rspace:                             1.0E-05
+ QS|                         eps_ppl:                                    1.0E-02
+ QS|                         eps_ppnl:                                   1.0E-07
+
+
+ ATOMIC KIND INFORMATION
+
+  1. Atomic kind: Zn                                    Number of atoms:       6
+
+     Orbital Basis Set                                    DZVP-MOLOPT-SR-GTH-q12
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               7
+       Number of primitive Cartesian functions:                                6
+       Number of Cartesian basis functions:                                   30
+       Number of spherical basis functions:                                   25
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                6.400813       0.070678
+                                                         3.167793      -0.182901
+                                                         1.341704       0.275787
+                                                         0.545418       0.070077
+                                                         0.222222      -0.163015
+                                                         0.079830      -0.058340
+
+                          1       2    3s                6.400813       0.159300
+                                                         3.167793      -0.240359
+                                                         1.341704      -0.028572
+                                                         0.545418      -0.590243
+                                                         0.222222       0.705234
+                                                         0.079830      -0.232595
+
+                          1       3    3px               6.400813       0.044197
+                                                         3.167793      -0.065115
+                                                         1.341704       0.233173
+                                                         0.545418      -0.041743
+                                                         0.222222      -0.119659
+                                                         0.079830      -0.031199
+                          1       3    3py               6.400813       0.044197
+                                                         3.167793      -0.065115
+                                                         1.341704       0.233173
+                                                         0.545418      -0.041743
+                                                         0.222222      -0.119659
+                                                         0.079830      -0.031199
+                          1       3    3pz               6.400813       0.044197
+                                                         3.167793      -0.065115
+                                                         1.341704       0.233173
+                                                         0.545418      -0.041743
+                                                         0.222222      -0.119659
+                                                         0.079830      -0.031199
+
+                          1       4    4px               6.400813       0.240176
+                                                         3.167793      -0.408028
+                                                         1.341704      -0.147214
+                                                         0.545418      -0.102288
+                                                         0.222222       0.357755
+                                                         0.079830      -0.080257
+                          1       4    4py               6.400813       0.240176
+                                                         3.167793      -0.408028
+                                                         1.341704      -0.147214
+                                                         0.545418      -0.102288
+                                                         0.222222       0.357755
+                                                         0.079830      -0.080257
+                          1       4    4pz               6.400813       0.240176
+                                                         3.167793      -0.408028
+                                                         1.341704      -0.147214
+                                                         0.545418      -0.102288
+                                                         0.222222       0.357755
+                                                         0.079830      -0.080257
+
+                          1       5    4dx2              6.400813      12.052935
+                                                         3.167793       4.421864
+                                                         1.341704       0.893324
+                                                         0.545418       0.127232
+                                                         0.222222       0.011466
+                                                         0.079830       0.000178
+                          1       5    4dxy              6.400813      20.876296
+                                                         3.167793       7.658893
+                                                         1.341704       1.547283
+                                                         0.545418       0.220373
+                                                         0.222222       0.019859
+                                                         0.079830       0.000308
+                          1       5    4dxz              6.400813      20.876296
+                                                         3.167793       7.658893
+                                                         1.341704       1.547283
+                                                         0.545418       0.220373
+                                                         0.222222       0.019859
+                                                         0.079830       0.000308
+                          1       5    4dy2              6.400813      12.052935
+                                                         3.167793       4.421864
+                                                         1.341704       0.893324
+                                                         0.545418       0.127232
+                                                         0.222222       0.011466
+                                                         0.079830       0.000178
+                          1       5    4dyz              6.400813      20.876296
+                                                         3.167793       7.658893
+                                                         1.341704       1.547283
+                                                         0.545418       0.220373
+                                                         0.222222       0.019859
+                                                         0.079830       0.000308
+                          1       5    4dz2              6.400813      12.052935
+                                                         3.167793       4.421864
+                                                         1.341704       0.893324
+                                                         0.545418       0.127232
+                                                         0.222222       0.011466
+                                                         0.079830       0.000178
+
+                          1       6    5dx2              6.400813      -3.077244
+                                                         3.167793      -1.397438
+                                                         1.341704      -0.501565
+                                                         0.545418       0.120936
+                                                         0.222222       0.032489
+                                                         0.079830       0.013923
+                          1       6    5dxy              6.400813      -5.329943
+                                                         3.167793      -2.420434
+                                                         1.341704      -0.868735
+                                                         0.545418       0.209468
+                                                         0.222222       0.056272
+                                                         0.079830       0.024116
+                          1       6    5dxz              6.400813      -5.329943
+                                                         3.167793      -2.420434
+                                                         1.341704      -0.868735
+                                                         0.545418       0.209468
+                                                         0.222222       0.056272
+                                                         0.079830       0.024116
+                          1       6    5dy2              6.400813      -3.077244
+                                                         3.167793      -1.397438
+                                                         1.341704      -0.501565
+                                                         0.545418       0.120936
+                                                         0.222222       0.032489
+                                                         0.079830       0.013923
+                          1       6    5dyz              6.400813      -5.329943
+                                                         3.167793      -2.420434
+                                                         1.341704      -0.868735
+                                                         0.545418       0.209468
+                                                         0.222222       0.056272
+                                                         0.079830       0.024116
+                          1       6    5dz2              6.400813      -3.077244
+                                                         3.167793      -1.397438
+                                                         1.341704      -0.501565
+                                                         0.545418       0.120936
+                                                         0.222222       0.032489
+                                                         0.079830       0.013923
+
+                          1       7    5fx3              6.400813      -0.041001
+                                                         3.167793       0.016340
+                                                         1.341704       0.068339
+                                                         0.545418       0.147998
+                                                         0.222222       0.008656
+                                                         0.079830       0.003475
+                          1       7    5fx2y             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fx2z             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fxy2             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fxyz             6.400813      -0.158795
+                                                         3.167793       0.063286
+                                                         1.341704       0.264674
+                                                         0.545418       0.573193
+                                                         0.222222       0.033523
+                                                         0.079830       0.013460
+                          1       7    5fxz2             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fy3              6.400813      -0.041001
+                                                         3.167793       0.016340
+                                                         1.341704       0.068339
+                                                         0.545418       0.147998
+                                                         0.222222       0.008656
+                                                         0.079830       0.003475
+                          1       7    5fy2z             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fyz2             6.400813      -0.091680
+                                                         3.167793       0.036538
+                                                         1.341704       0.152810
+                                                         0.545418       0.330933
+                                                         0.222222       0.019354
+                                                         0.079830       0.007771
+                          1       7    5fz3              6.400813      -0.041001
+                                                         3.167793       0.016340
+                                                         1.341704       0.068339
+                                                         0.545418       0.147998
+                                                         0.222222       0.008656
+                                                         0.079830       0.003475
+
+     GTH Potential information for                                   GTH-PBE-q12
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               1.922338
+       Electronic configuration (s p d ...):                           2   0  10
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.510000
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.400316   11.530041   -8.791898    3.145086
+                                   -8.791898   16.465775   -8.120578
+                                    3.145086   -8.120578    6.445509
+                   1    0.543182    2.597195   -0.594263
+                                   -0.594263    0.703141
+                   2    0.250959  -14.466958
+
+  2. Atomic kind: H                                     Number of atoms:       6
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q1
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               3
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                    5
+       Number of spherical basis functions:                                    5
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s               10.068468      -0.133023
+                                                         2.680223      -0.177618
+                                                         0.791502      -0.258419
+                                                         0.239116      -0.107525
+                                                         0.082193      -0.014019
+
+                          1       2    3s               10.068468       0.344673
+                                                         2.680223       1.819821
+                                                         0.791502      -0.999069
+                                                         0.239116       0.017430
+                                                         0.082193       0.082660
+
+                          1       3    3px              10.068468       0.155326
+                                                         2.680223       0.367157
+                                                         0.791502       0.311480
+                                                         0.239116       0.080105
+                                                         0.082193       0.033440
+                          1       3    3py              10.068468       0.155326
+                                                         2.680223       0.367157
+                                                         0.791502       0.311480
+                                                         0.239116       0.080105
+                                                         0.082193       0.033440
+                          1       3    3pz              10.068468       0.155326
+                                                         2.680223       0.367157
+                                                         0.791502       0.311480
+                                                         0.239116       0.080105
+                                                         0.082193       0.033440
+
+     GTH Potential information for                                    GTH-PBE-q1
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:              12.500000
+       Electronic configuration (s p d ...):                                   1
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.200000   -4.178900    0.724463
+
+  3. Atomic kind: C                                     Number of atoms:      25
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q4
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s                5.605331       0.322515
+                                                         2.113016       0.213043
+                                                         0.769911      -0.209686
+                                                         0.348157      -0.219794
+                                                         0.128212      -0.022789
+
+                          1       2    3s                5.605331       0.552234
+                                                         2.113016       0.082072
+                                                         0.769911       0.007843
+                                                         0.348157       0.136893
+                                                         0.128212       0.074283
+
+                          1       3    3px               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+                          1       3    3py               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+                          1       3    3pz               5.605331      -0.703879
+                                                         2.113016      -0.642521
+                                                         0.769911      -0.374851
+                                                         0.348157      -0.139743
+                                                         0.128212      -0.027849
+
+                          1       4    4px               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+                          1       4    4py               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+                          1       4    4pz               5.605331      -0.480376
+                                                         2.113016      -0.552894
+                                                         0.769911      -0.316145
+                                                         0.348157       0.210505
+                                                         0.128212       0.076095
+
+                          1       5    4dx2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+                          1       5    4dxy              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dxz              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dy2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+                          1       5    4dyz              5.605331       1.108557
+                                                         2.113016       0.475102
+                                                         0.769911       0.773726
+                                                         0.348157       0.049666
+                                                         0.128212       0.051599
+                          1       5    4dz2              5.605331       0.640026
+                                                         2.113016       0.274300
+                                                         0.769911       0.446711
+                                                         0.348157       0.028674
+                                                         0.128212       0.029790
+
+     GTH Potential information for                                    GTH-PBE-q4
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               4.364419
+       Electronic configuration (s p d ...):                               2   2
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.338471   -8.803674    1.339211
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.302576    9.622487
+                   1    0.291507
+
+  4. Atomic kind: O                                     Number of atoms:      20
+
+     Orbital Basis Set                                     DZVP-MOLOPT-SR-GTH-q6
+
+       Number of orbital shell sets:                                           1
+       Number of orbital shells:                                               5
+       Number of primitive Cartesian functions:                                5
+       Number of Cartesian basis functions:                                   14
+       Number of spherical basis functions:                                   13
+       Norm type:                                                              2
+
+       Normalised Cartesian orbitals:
+
+                        Set   Shell   Orbital            Exponent    Coefficient
+
+                          1       1    2s               10.389228       0.396646
+                                                         3.849621       0.208811
+                                                         1.388401      -0.301641
+                                                         0.496955      -0.274061
+                                                         0.162492      -0.033677
+
+                          1       2    3s               10.389228       0.303673
+                                                         3.849621       0.240943
+                                                         1.388401      -0.313066
+                                                         0.496955      -0.043055
+                                                         0.162492       0.213991
+
+                          1       3    3px              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+                          1       3    3py              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+                          1       3    3pz              10.389228      -1.530415
+                                                         3.849621      -1.371928
+                                                         1.388401      -0.761951
+                                                         0.496955      -0.253695
+                                                         0.162492      -0.035541
+
+                          1       4    4px              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+                          1       4    4py              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+                          1       4    4pz              10.389228      -0.565392
+                                                         3.849621      -0.038231
+                                                         1.388401      -0.382373
+                                                         0.496955       0.179070
+                                                         0.162492       0.122714
+
+                          1       5    4dx2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+                          1       5    4dxy             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dxz             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dy2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+                          1       5    4dyz             10.389228       3.234392
+                                                         3.849621       1.162195
+                                                         1.388401       2.344229
+                                                         0.496955       0.473781
+                                                         0.162492       0.011466
+                          1       5    4dz2             10.389228       1.867377
+                                                         3.849621       0.670994
+                                                         1.388401       1.353441
+                                                         0.496955       0.273538
+                                                         0.162492       0.006620
+
+     GTH Potential information for                                    GTH-PBE-q6
+
+       Description:                       Goedecker-Teter-Hutter pseudopotential
+                                           Goedecker et al., PRB 54, 1703 (1996)
+                                          Hartwigsen et al., PRB 58, 3641 (1998)
+                                                      Krack, TCA 114, 145 (2005)
+
+       Gaussian exponent of the core charge distribution:               8.360253
+       Electronic configuration (s p d ...):                               2   4
+
+       Parameters of the local part of the GTH pseudopotential:
+
+                          rloc        C1          C2          C3          C4
+                        0.244554  -16.667215    2.487311
+
+       Parameters of the non-local part of the GTH pseudopotential:
+
+                   l      r(l)      h(i,j,l)
+
+                   0    0.220956   18.337458
+                   1    0.211332
+
+
+ MOLECULE KIND INFORMATION
+
+
+ All atoms are their own molecule, skipping detailed information
+
+
+ TOTAL NUMBERS AND MAXIMUM NUMBERS
+
+  Total number of            - Atomic kinds:                                   4
+                             - Atoms:                                         57
+                             - Shell sets:                                    57
+                             - Shells:                                       285
+                             - Primitive Cartesian functions:                291
+                             - Cartesian basis functions:                    840
+                             - Spherical basis functions:                    765
+
+  Maximum angular momentum of- Orbital basis functions:                        3
+                             - Local part of the GTH pseudopotential:          2
+                             - Non-local part of the GTH pseudopotential:      4
+
+
+ MODULE QUICKSTEP:  ATOMIC COORDINATES IN angstrom
+
+  Atom  Kind  Element       X           Y           Z          Z(eff)       Mass
+
+       1     1 Zn  30   -0.383625    4.293611    6.600223     12.00      65.3800
+       2     1 Zn  30    2.159815    5.301947    7.779863     12.00      65.3800
+       3     1 Zn  30    4.480115    3.451223    7.517364     12.00      65.3800
+       4     1 Zn  30    3.841016    8.753170    0.486751     12.00      65.3800
+       5     1 Zn  30    1.297611    7.744704   -0.692817     12.00      65.3800
+       6     1 Zn  30   -1.022759    9.595428   -0.430460     12.00      65.3800
+       7     2 H    1    4.482787    0.326675    6.269586      1.00       1.0079
+       8     2 H    1   -0.512588    6.923320    4.505711      1.00       1.0079
+       9     2 H    1    2.859209    5.797047   11.033385      1.00       1.0079
+      10     2 H    1   -1.025431   12.719976    0.817165      1.00       1.0079
+      11     2 H    1    3.969979    6.123462    2.581264      1.00       1.0079
+      12     2 H    1    0.598147    7.249603   -3.946328      1.00       1.0079
+      13     3 C    6    1.847192    2.234671    7.703263      4.00      12.0107
+      14     3 C    6    0.863924    1.115183    7.649961      4.00      12.0107
+      15     3 C    6    6.377042    1.321703    6.419893      4.00      12.0107
+      16     3 C    6    5.556141    0.189038    6.393652      4.00      12.0107
+      17     3 C    6    3.788779    5.091774    4.998794      4.00      12.0107
+      18     3 C    6    2.703758    5.827445    4.288289      4.00      12.0107
+      19     3 C    6    1.413046    6.046098    4.857577      4.00      12.0107
+      20     3 C    6    0.476664    6.743674    4.086548      4.00      12.0107
+      21     3 C    6   -0.261767    5.720467    9.332098      4.00      12.0107
+      22     3 C    6   -1.050040    6.104414   10.537978      4.00      12.0107
+      23     3 C    6    4.520985    5.679110    9.682078      4.00      12.0107
+      24     3 C    6    3.884975    6.114329   10.849971      4.00      12.0107
+      25     3 C    6    1.610199   10.812110   -0.616593      4.00      12.0107
+      26     3 C    6    2.593398   11.931598   -0.563280      4.00      12.0107
+      27     3 C    6   -2.919721   11.725078    0.666788      4.00      12.0107
+      28     3 C    6   -2.098784   12.857612    0.693100      4.00      12.0107
+      29     3 C    6   -0.331423    7.955138    2.088110      4.00      12.0107
+      30     3 C    6    0.753633    7.219336    2.798686      4.00      12.0107
+      31     3 C    6    2.044379    7.000814    2.229468      4.00      12.0107
+      32     3 C    6    2.980692    6.303237    3.000509      4.00      12.0107
+      33     3 C    6    3.719192    7.326184   -2.244900      4.00      12.0107
+      34     3 C    6    4.507397    6.942237   -3.450922      4.00      12.0107
+      35     3 C    6   -1.063664    7.367410   -2.595245      4.00      12.0107
+      36     3 C    6   -0.427584    6.932191   -3.762996      4.00      12.0107
+      37     4 O    8    1.377982    3.429566    7.648309      6.00      15.9994
+      38     4 O    8    3.094194    1.983664    7.794712      6.00      15.9994
+      39     4 O    8    5.787621    2.541908    6.286912      6.00      15.9994
+      40     4 O    8    3.507212    4.603457    6.153450      6.00      15.9994
+      41     4 O    8    4.938109    4.973837    4.458421      6.00      15.9994
+      42     4 O    8    1.036370    5.627970    6.097393      6.00      15.9994
+      43     4 O    8   -0.860163    5.013497    8.441294      6.00      15.9994
+      44     4 O    8    0.954027    6.089542    9.221463      6.00      15.9994
+      45     4 O    8    3.820924    4.876904    8.833239      6.00      15.9994
+      46     4 O    8    2.079374    9.617084   -0.561405      6.00      15.9994
+      47     4 O    8    0.363162   11.062987   -0.707808      6.00      15.9994
+      48     4 O    8   -2.330264   10.504743    0.799992      6.00      15.9994
+      49     4 O    8   -0.049786    8.443194    0.933596      6.00      15.9994
+      50     4 O    8   -1.480753    8.073075    2.628483      6.00      15.9994
+      51     4 O    8    2.420986    7.418942    0.989510      6.00      15.9994
+      52     4 O    8    4.317519    8.032893   -1.354390      6.00      15.9994
+      53     4 O    8    2.503330    6.957109   -2.134407      6.00      15.9994
+      54     4 O    8   -0.363568    8.169486   -1.746335      6.00      15.9994
+      55     3 C    6    5.922650    0.971024    9.644414      4.00      12.0107
+      56     4 O    8    5.627701    2.095563    9.433385      6.00      15.9994
+      57     4 O    8    2.756503   12.905778    2.804537      6.00      15.9994
+
+
+
+
+ SCF PARAMETERS         Density guess:                                    ATOMIC
+                        --------------------------------------------------------
+                        max_scf:                                              50
+                        max_scf_history:                                       0
+                        max_diis:                                              4
+                        --------------------------------------------------------
+                        eps_scf:                                        1.00E-04
+                        eps_scf_history:                                0.00E+00
+                        eps_diis:                                       1.00E-01
+                        eps_eigval:                                     1.00E-05
+                        --------------------------------------------------------
+                        level_shift [a.u.]:                                 0.00
+                        --------------------------------------------------------
+                        Outer loop SCF in use 
+                        No variables optimised in outer loop
+                        eps_scf                                         1.00E-04
+                        max_scf                                                5
+                        No outer loop optimization
+                        step_size                                       5.00E-01
+
+ PW_GRID| Information for grid number                                         21
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                    150.0
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -37      37                Points:          75
+ PW_GRID|   Bounds   2            -80      79                Points:         160
+ PW_GRID|   Bounds   3            -80      79                Points:         160
+ PW_GRID| Volume element (a.u.^3)  0.4835E-02     Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                           480000.0      480000      480000
+ PW_GRID|   G-Rays                                6400.0        6400        6400
+ PW_GRID|   Real Space Points                   480000.0      486400      460800
+
+ PW_GRID| Information for grid number                                         22
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                     50.0
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -22      22                Points:          45
+ PW_GRID|   Bounds   2            -48      47                Points:          96
+ PW_GRID|   Bounds   3            -48      47                Points:          96
+ PW_GRID| Volume element (a.u.^3)  0.2238E-01     Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                           103680.0      103725      103635
+ PW_GRID|   G-Rays                                2304.0        2305        2303
+ PW_GRID|   Real Space Points                   103680.0      110592      101376
+
+ PW_GRID| Information for grid number                                         23
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                     16.7
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1            -12      12                Points:          25
+ PW_GRID|   Bounds   2            -27      26                Points:          54
+ PW_GRID|   Bounds   3            -27      26                Points:          54
+ PW_GRID| Volume element (a.u.^3)  0.1273         Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                            18225.0       18225       18225
+ PW_GRID|   G-Rays                                 729.0         729         729
+ PW_GRID|   Real Space Points                    18225.0       20412       17496
+
+ PW_GRID| Information for grid number                                         24
+ PW_GRID| Grid distributed over                                     4 processors
+ PW_GRID| Real space group dimensions                                     4    1
+ PW_GRID| the grid is blocked:                                                NO
+ PW_GRID| Cutoff [a.u.]                                                      5.6
+ PW_GRID| spherical cutoff:                                                   NO
+ PW_GRID|   Bounds   1             -7       7                Points:          15
+ PW_GRID|   Bounds   2            -16      15                Points:          32
+ PW_GRID|   Bounds   3            -16      15                Points:          32
+ PW_GRID| Volume element (a.u.^3)  0.6043         Volume (a.u.^3)      9282.5169
+ PW_GRID| Grid span                                                    FULLSPACE
+ PW_GRID|   Distribution                         Average         Max         Min
+ PW_GRID|   G-Vectors                             3840.0        3855        3825
+ PW_GRID|   G-Rays                                 256.0         257         255
+ PW_GRID|   Real Space Points                     3840.0        4096        3072
+
+ POISSON| Solver                                                        PERIODIC
+ POISSON| Periodicity                                                        XYZ
+
+ RS_GRID| Information for grid number                                         21
+ RS_GRID|   Bounds   1            -37      37                Points:          75
+ RS_GRID|   Bounds   2            -80      79                Points:         160
+ RS_GRID|   Bounds   3            -80      79                Points:         160
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                         22
+ RS_GRID|   Bounds   1            -22      22                Points:          45
+ RS_GRID|   Bounds   2            -48      47                Points:          96
+ RS_GRID|   Bounds   3            -48      47                Points:          96
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                         23
+ RS_GRID|   Bounds   1            -12      12                Points:          25
+ RS_GRID|   Bounds   2            -27      26                Points:          54
+ RS_GRID|   Bounds   3            -27      26                Points:          54
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ RS_GRID| Information for grid number                                         24
+ RS_GRID|   Bounds   1             -7       7                Points:          15
+ RS_GRID|   Bounds   2            -16      15                Points:          32
+ RS_GRID|   Bounds   3            -16      15                Points:          32
+ RS_GRID| Real space fully replicated
+ RS_GRID| Group size                                                           1
+
+ DISTRIBUTION OF THE PARTICLES (ROWS)
+              Process row      Number of particles         Number of matrix rows
+                        0                       29                            -1
+                        1                       28                            -1
+                      Sum                       57                            -1
+
+ DISTRIBUTION OF THE PARTICLES (COLUMNS)
+              Process col      Number of particles      Number of matrix columns
+                        0                       29                            -1
+                        1                       28                            -1
+                      Sum                       57                            -1
+
+ DISTRIBUTION OF THE NEIGHBOR LISTS
+              Total number of particle pairs:                               6196
+              Total number of matrix elements:                           1216356
+              Average number of particle pairs:                             1549
+              Maximum number of particle pairs:                             1690
+              Average number of matrix element:                           304089
+              Maximum number of matrix elements:                          314098
+
+
+ DISTRIBUTION OF THE OVERLAP MATRIX
+              Number  of non-zero blocks:                                   1653
+              Percentage non-zero blocks:                                 100.00
+              Average number of blocks per CPU:                              414
+              Maximum number of blocks per CPU:                              435
+              Average number of matrix elements per CPU:                   74602
+              Maximum number of matrix elements per CPU:                   76644
+
+ Number of electrons:                                                        298
+ Number of occupied orbitals:                                                149
+ Number of molecular orbitals:                                               149
+
+ Number of orbital functions:                                                765
+ Number of independent orbital functions:                                    765
+
+ Extrapolation method: initial_guess
+
+ Atomic guess: The first density matrix is obtained in terms of atomic orbitals
+               and electronic configurations assigned to each atomic kind
+
+ Guess for atomic kind: Zn
+
+ Electronic structure
+    Total number of core electrons                                         18.00
+    Total number of valence electrons                                      12.00
+    Total number of electrons                                              30.00
+    Multiplicity                                                   not specified
+    S   [  2.00  2.00  2.00] 2.00
+    P   [  6.00  6.00]
+    D     10.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1         1.62924                     -59.451394251983
+                          2         9.44946                     -57.380718340026
+                          3         1.20534                     -60.073283596570
+                          4        0.228441                     -60.149512613300
+                          5        0.659017E-01                 -60.153075514012
+                          6        0.364244E-01                 -60.153290281981
+                          7        0.826658E-01                 -60.152916515694
+                          8        0.577629E-03                 -60.153383695723
+                          9        0.361798E-03                 -60.153383709870
+                         10        0.208007E-03                 -60.153383715984
+                         11        0.873205E-04                 -60.153383718472
+                         12        0.217219E-05                 -60.153383719003
+                         13        0.826432E-08                 -60.153383719004
+
+ Energy components [Hartree]           Total Energy ::          -60.153383719004
+                                        Band Energy ::           -3.832693908022
+                                     Kinetic Energy ::           84.396829637188
+                                   Potential Energy ::         -144.550213356191
+                                      Virial (-V/T) ::            1.712744589786
+                                        Core Energy ::         -110.535288508001
+                                          XC Energy ::           -8.666206286402
+                                     Coulomb Energy ::           59.048111075399
+                       Total Pseudopotential Energy ::         -195.030087576096
+                       Local Pseudopotential Energy ::         -135.966032502182
+                    Nonlocal Pseudopotential Energy ::          -59.064055073914
+                                        Confinement ::            0.979694309070
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.191113           -5.200458
+
+                       1     2         10.000      -0.345047           -9.389199
+
+
+ Total Electron Density at R=0:                                         0.000033
+
+ Guess for atomic kind: H
+
+ Electronic structure
+    Total number of core electrons                                          0.00
+    Total number of valence electrons                                       1.00
+    Total number of electrons                                               1.00
+    Multiplicity                                                   not specified
+    S      1.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1        0.250972E-02                  -0.375256815885
+                          2        0.570752E-04                  -0.375258666164
+                          3        0.832405E-09                  -0.375258667122
+
+ Energy components [Hartree]           Total Energy ::           -0.375258667122
+                                        Band Energy ::           -0.076317618391
+                                     Kinetic Energy ::            0.771356566341
+                                   Potential Energy ::           -1.146615233463
+                                      Virial (-V/T) ::            1.486491829455
+                                        Core Energy ::           -0.456090715790
+                                          XC Energy ::           -0.314218627334
+                                     Coulomb Energy ::            0.395050676003
+                       Total Pseudopotential Energy ::           -1.238482237174
+                       Local Pseudopotential Energy ::           -1.238482237174
+                    Nonlocal Pseudopotential Energy ::            0.000000000000
+                                        Confinement ::            0.110349550431
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          1.000      -0.076318           -2.076708
+
+
+ Total Electron Density at R=0:                                         0.425022
+
+ Guess for atomic kind: C
+
+ Electronic structure
+    Total number of core electrons                                          2.00
+    Total number of valence electrons                                       4.00
+    Total number of electrons                                               6.00
+    Multiplicity                                                   not specified
+    S   [  2.00] 2.00
+    P      2.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1        0.457038                      -5.151105664215
+                          2        0.157450                      -5.235617431356
+                          3        0.130137E-02                  -5.246564342251
+                          4        0.531061E-03                  -5.246565033610
+                          5        0.605965E-04                  -5.246565167704
+                          6        0.323545E-04                  -5.246565168968
+                          7        0.365472E-07                  -5.246565169473
+
+ Energy components [Hartree]           Total Energy ::           -5.246565169473
+                                        Band Energy ::           -1.058732656762
+                                     Kinetic Energy ::            3.518928154187
+                                   Potential Energy ::           -8.765493323660
+                                      Virial (-V/T) ::            2.490955467002
+                                        Core Energy ::           -8.429377161979
+                                          XC Energy ::           -1.450183339326
+                                     Coulomb Energy ::            4.632995331832
+                       Total Pseudopotential Energy ::          -11.978048785149
+                       Local Pseudopotential Energy ::          -12.816738149676
+                    Nonlocal Pseudopotential Energy ::            0.838689364526
+                                        Confinement ::            0.297434689834
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.410911          -11.181458
+
+                       1     1          2.000      -0.118455           -3.223332
+
+
+ Total Electron Density at R=0:                                         0.001337
+
+ Guess for atomic kind: O
+
+ Electronic structure
+    Total number of core electrons                                          2.00
+    Total number of valence electrons                                       6.00
+    Total number of electrons                                               8.00
+    Multiplicity                                                   not specified
+    S   [  2.00] 2.00
+    P      4.00
+
+
+ *******************************************************************************
+                  Iteration          Convergence                     Energy [au]
+ *******************************************************************************
+                          1         1.67054                     -14.836051221656
+                          2         2.12470                     -14.897900780399
+                          3        0.100150                     -15.654295189160
+                          4        0.189307E-01                 -15.655828842238
+                          5        0.464435E-02                 -15.655882433232
+                          6        0.259395E-02                 -15.655884790195
+                          7        0.516014E-04                 -15.655885857622
+                          8        0.157374E-05                 -15.655885858066
+                          9        0.783512E-06                 -15.655885858066
+
+ Energy components [Hartree]           Total Energy ::          -15.655885858066
+                                        Band Energy ::           -2.983129541149
+                                     Kinetic Energy ::           11.754767937471
+                                   Potential Energy ::          -27.410653795537
+                                      Virial (-V/T) ::            2.331875366774
+                                        Core Energy ::          -26.153524299614
+                                          XC Energy ::           -3.157392735430
+                                     Coulomb Energy ::           13.655031176977
+                       Total Pseudopotential Energy ::          -37.943031004163
+                       Local Pseudopotential Energy ::          -39.220423834999
+                    Nonlocal Pseudopotential Energy ::            1.277392830837
+                                        Confinement ::            0.347387670777
+
+ Orbital energies  State     L     Occupation   Energy[a.u.]          Energy[eV]
+
+                       1     0          2.000      -0.861523          -23.443221
+
+                       1     1          4.000      -0.315021           -8.572160
+
+
+ Total Electron Density at R=0:                                         0.000093
+ Re-scaling the density matrix to get the right number of electrons
+                  # Electrons              Trace(P)               Scaling factor
+                          298               298.011                        1.000
+
+
+ SCF WAVEFUNCTION OPTIMIZATION
+
+  ----------------------------------- OT ---------------------------------------
+  Minimizer      : DIIS                : direct inversion
+                                         in the iterative subspace
+                                         using   7 DIIS vectors
+                                         safer DIIS on
+  Preconditioner : FULL_ALL            : diagonalization, state selective
+  Precond_solver : DEFAULT
+  stepsize       :    0.15000000                  energy_gap     :    0.08000000
+  eps_taylor     :   0.10000E-15                  max_taylor     :             4
+  ----------------------------------- OT ---------------------------------------
+
+  Step     Update method      Time    Convergence         Total energy    Change
+  ------------------------------------------------------------------------------
+     1 OT DIIS     0.15E+00    2.0     0.05339449      -807.7482096721 -8.08E+02
+     2 OT DIIS     0.15E+00    2.5     0.04558550      -817.4008457206 -9.65E+00
+     3 OT DIIS     0.15E+00    2.5     0.03055418      -823.4925032218 -6.09E+00
+     4 OT DIIS     0.15E+00    2.8     0.02892201      -826.0875643734 -2.60E+00
+     5 OT DIIS     0.15E+00    2.4     0.01502814      -827.6291269730 -1.54E+00
+     6 OT DIIS     0.15E+00    2.4     0.01243488      -828.3087315475 -6.80E-01
+     7 OT DIIS     0.15E+00    2.4     0.00757380      -828.9535951410 -6.45E-01
+     8 OT DIIS     0.15E+00    2.4     0.00566046      -829.3753904766 -4.22E-01
+     9 OT DIIS     0.15E+00    2.4     0.00501655      -829.6035165494 -2.28E-01
+    10 OT DIIS     0.15E+00    2.4     0.00427206      -829.6958889466 -9.24E-02
+    11 OT DIIS     0.15E+00    2.6     0.00326497      -829.7685335608 -7.26E-02
+    12 OT DIIS     0.15E+00    2.5     0.00229577      -829.8338398442 -6.53E-02
+    13 OT DIIS     0.15E+00    2.5     0.00171557      -829.8688771331 -3.50E-02
+    14 OT DIIS     0.15E+00    2.5     0.00132456      -829.8846141170 -1.57E-02
+    15 OT DIIS     0.15E+00    2.4     0.00109187      -829.8966829738 -1.21E-02
+    16 OT DIIS     0.15E+00    2.4     0.00072814      -829.9039363242 -7.25E-03
+    17 OT DIIS     0.15E+00    2.4     0.00056215      -829.9090193261 -5.08E-03
+    18 OT DIIS     0.15E+00    2.5     0.00055483      -829.9118102752 -2.79E-03
+    19 OT DIIS     0.15E+00    2.5     0.00044504      -829.9136763357 -1.87E-03
+    20 OT DIIS     0.15E+00    2.5     0.00030550      -829.9154425364 -1.77E-03
+    21 OT DIIS     0.15E+00    2.4     0.00027186      -829.9168970305 -1.45E-03
+    22 OT DIIS     0.15E+00    2.6     0.00023334      -829.9179023553 -1.01E-03
+    23 OT DIIS     0.15E+00    3.1     0.00020513      -829.9186748338 -7.72E-04
+    24 OT DIIS     0.15E+00    3.8     0.00018525      -829.9192199613 -5.45E-04
+    25 OT DIIS     0.15E+00    2.4     0.00015114      -829.9197347127 -5.15E-04
+    26 OT DIIS     0.15E+00    2.4     0.00014063      -829.9200838996 -3.49E-04
+    27 OT DIIS     0.15E+00    2.6     0.00013960      -829.9202930659 -2.09E-04
+    28 OT DIIS     0.15E+00    2.7     0.00010715      -829.9205061138 -2.13E-04
+    29 OT DIIS     0.15E+00    2.6     0.00008704      -829.9206983939 -1.92E-04
+
+  *** SCF run converged in    29 steps ***
+
+
+  Electronic density on regular grids:       -297.9999997534        0.0000002466
+  Core density on regular grids:              297.9999999817       -0.0000000183
+  Total charge density on r-space grids:        0.0000002283
+  Total charge density g-space grids:           0.0000002283
+
+  Overlap energy of the core charge distribution:               0.00000799818028
+  Self energy of the core charge distribution:              -1650.26394838983515
+  Core Hamiltonian energy:                                    498.41352721717129
+  Hartree energy:                                             492.33383187323511
+  Exchange-correlation energy:                               -170.24190488023748
+  Dispersion energy:                                           -0.16221221242898
+
+  Total energy:                                              -829.92069839391502
+
+  outer SCF iter =    1 RMS gradient =   0.87E-04 energy =       -829.9206983939
+  outer SCF loop converged in   1 iterations or   29 steps
+
+
+ !-----------------------------------------------------------------------------!
+                     Mulliken Population Analysis
+
+ #  Atom  Element  Kind  Atomic population                           Net charge
+       1     Zn       1         11.377933                              0.622067
+       2     Zn       1         11.374465                              0.625535
+       3     Zn       1         11.382278                              0.617722
+       4     Zn       1         11.372360                              0.627640
+       5     Zn       1         11.374865                              0.625135
+       6     Zn       1         11.373814                              0.626186
+       7     H        2          0.922596                              0.077404
+       8     H        2          0.923040                              0.076960
+       9     H        2          0.923379                              0.076621
+      10     H        2          0.924986                              0.075014
+      11     H        2          0.922959                              0.077041
+      12     H        2          0.923341                              0.076659
+      13     C        3          3.785538                              0.214462
+      14     C        3          4.048166                             -0.048166
+      15     C        3          3.919793                              0.080207
+      16     C        3          4.023772                             -0.023772
+      17     C        3          3.784421                              0.215579
+      18     C        3          4.043571                             -0.043571
+      19     C        3          3.911744                              0.088256
+      20     C        3          4.015273                             -0.015273
+      21     C        3          3.782687                              0.217313
+      22     C        3          4.042745                             -0.042745
+      23     C        3          3.910476                              0.089524
+      24     C        3          4.016374                             -0.016374
+      25     C        3          3.782263                              0.217737
+      26     C        3          4.043707                             -0.043707
+      27     C        3          3.910624                              0.089376
+      28     C        3          4.016829                             -0.016829
+      29     C        3          3.783161                              0.216839
+      30     C        3          4.043195                             -0.043195
+      31     C        3          3.911440                              0.088560
+      32     C        3          4.016492                             -0.016492
+      33     C        3          3.783422                              0.216578
+      34     C        3          4.043953                             -0.043953
+      35     C        3          3.911954                              0.088046
+      36     C        3          4.016367                             -0.016367
+      37     O        4          6.289969                             -0.289969
+      38     O        4          6.283501                             -0.283501
+      39     O        4          6.373619                             -0.373619
+      40     O        4          6.290401                             -0.290401
+      41     O        4          6.282206                             -0.282206
+      42     O        4          6.375564                             -0.375564
+      43     O        4          6.292736                             -0.292736
+      44     O        4          6.282734                             -0.282734
+      45     O        4          6.377032                             -0.377032
+      46     O        4          6.290006                             -0.290006
+      47     O        4          6.284354                             -0.284354
+      48     O        4          6.375683                             -0.375683
+      49     O        4          6.292780                             -0.292780
+      50     O        4          6.280656                             -0.280656
+      51     O        4          6.374962                             -0.374962
+      52     O        4          6.292172                             -0.292172
+      53     O        4          6.281898                             -0.281898
+      54     O        4          6.375026                             -0.375026
+      55     C        3          3.493190                              0.506810
+      56     O        4          6.262070                             -0.262070
+      57     O        4          6.205457                             -0.205457
+ # Total charge                            298.000000                 -0.000000
+
+ !-----------------------------------------------------------------------------!
+  
+  Eigenvalues of the occupied subspace spin            1
+ ---------------------------------------------
+      -0.95359553     -0.91782227     -0.89011546     -0.88868094
+      -0.88549967     -0.88476466     -0.88416513     -0.88293638
+      -0.81576984     -0.81411120     -0.81399583     -0.81337999
+      -0.81205513     -0.81028306     -0.80101859     -0.80005959
+      -0.79971661     -0.79930587     -0.79840654     -0.79715039
+      -0.66220742     -0.65904684     -0.65776805     -0.59353184
+      -0.59044700     -0.58921609     -0.54502325     -0.54023207
+      -0.53850651     -0.50015990     -0.49770000     -0.49672543
+      -0.43873289     -0.43357481     -0.43173812     -0.43020343
+      -0.42320365     -0.42209191     -0.41877289     -0.40111390
+      -0.39787331     -0.39705241     -0.37338147     -0.37271964
+      -0.37227202     -0.37166414     -0.36898809     -0.36748720
+      -0.35702189     -0.35344988     -0.34995372     -0.34818092
+      -0.34638496     -0.34604289     -0.34556950     -0.34404292
+      -0.34250157     -0.33256782     -0.32758872     -0.32700531
+      -0.32071981     -0.31966953     -0.31654777     -0.30546259
+      -0.30502971     -0.30412345     -0.30313432     -0.29797487
+      -0.29745766     -0.29649641     -0.29495845     -0.29026869
+      -0.28936038     -0.28906975     -0.28783981     -0.28585149
+      -0.28529142     -0.28097825     -0.28037927     -0.27975634
+      -0.27896849     -0.27749085     -0.27485524     -0.27302662
+      -0.27245722     -0.27146719     -0.27089753     -0.26974259
+      -0.26877211     -0.26815236     -0.26728563     -0.26699091
+      -0.26524061     -0.26470812     -0.26396882     -0.26064591
+      -0.25885332     -0.25725706     -0.25560909     -0.25345166
+      -0.25284547     -0.24907573     -0.24873875     -0.23974830
+      -0.23637516     -0.23141455     -0.23082165     -0.22994444
+      -0.22742208     -0.22611678     -0.22376326     -0.21819019
+      -0.21713555     -0.21493914     -0.20937062     -0.20821483
+      -0.19604117     -0.18710574     -0.18570717     -0.18454341
+      -0.18141092     -0.18120769     -0.16895353     -0.16822330
+      -0.16213668     -0.16131245     -0.15811887     -0.15716976
+      -0.15337408     -0.15287082     -0.15211266     -0.15185745
+      -0.15142035     -0.14405240     -0.13864340     -0.13835902
+      -0.13555331     -0.12708042     -0.12399982     -0.12260058
+      -0.12020082     -0.11778906     -0.11701972     -0.11257783
+      -0.10711341     -0.10600515     -0.07548463     -0.07331737
+      -0.06796769
+ Fermi Energy [eV] :   -1.849495
+  
+  Lowest Eigenvalues of the unoccupied subspace spin            1
+ -----------------------------------------------------
+  Reached convergence in          221  iterations 
+       0.01228455
+  
+ HOMO - LUMO gap [eV] :    2.183774
+
+ -------------------------------------------------------------------------------
+ ----                             MULTIGRID INFO                            ----
+ -------------------------------------------------------------------------------
+ count for grid        1:         101342          cutoff [a.u.]          150.00
+ count for grid        2:          54840          cutoff [a.u.]           50.00
+ count for grid        3:          43882          cutoff [a.u.]           16.67
+ count for grid        4:          19313          cutoff [a.u.]            5.56
+ total gridlevel count  :         219377
+
+ -------------------------------------------------------------------------------
+ -                                                                             -
+ -                                 BSSE RESULTS                                -
+ -                                                                             -
+ -                 CP-corrected Total energy:     -829.918747                  -
+ -                                                                             -
+ -                       1-body contribution:     -792.146217                  -
+ -                       1-body contribution:      -37.761858                  -
+ -                                                                             -
+ -                       2-body contribution:       -0.010671                  -
+ -                 BSSE-free interaction energy:       -0.010671               -
+ -------------------------------------------------------------------------------
+
+ -------------------------------------------------------------------------------
+ -                                                                             -
+ -                                DBCSR STATISTICS                             -
+ -                                                                             -
+ -------------------------------------------------------------------------------
+ COUNTER                                    TOTAL       BLAS       SMM       ACC
+ flops     8 x     1 x    13                  832     100.0%      0.0%      0.0%
+ flops    13 x     1 x     8                  832     100.0%      0.0%      0.0%
+ flops     8 x     1 x    26                 1664     100.0%      0.0%      0.0%
+ flops    26 x     1 x     8                 1664     100.0%      0.0%      0.0%
+ flops     8 x     1 x     8                 3840     100.0%      0.0%      0.0%
+ flops     1 x     1 x    13                 6110     100.0%      0.0%      0.0%
+ flops     9 x     9 x    13                 8424     100.0%      0.0%      0.0%
+ flops     1 x     1 x    26                12220     100.0%      0.0%      0.0%
+ flops     9 x     1 x    13                14274     100.0%      0.0%      0.0%
+ flops    13 x     1 x     9                14274     100.0%      0.0%      0.0%
+ flops     9 x     9 x    26                16848     100.0%      0.0%      0.0%
+ flops     5 x    21 x    21                26460     100.0%      0.0%      0.0%
+ flops     9 x     1 x    26                28548     100.0%      0.0%      0.0%
+ flops    26 x     1 x     9                28548     100.0%      0.0%      0.0%
+ flops    85 x     1 x    64                65280     100.0%      0.0%      0.0%
+ flops    64 x     1 x    85                65280     100.0%      0.0%      0.0%
+ flops    85 x     1 x    85                86700     100.0%      0.0%      0.0%
+ flops     9 x     1 x     9                93636     100.0%      0.0%      0.0%
+ flops     8 x     8 x    13                94848     100.0%      0.0%      0.0%
+ flops     5 x     5 x     8               109200     100.0%      0.0%      0.0%
+ flops    13 x     8 x     8               109824     100.0%      0.0%      0.0%
+ flops    25 x    21 x    21               132300     100.0%      0.0%      0.0%
+ flops    13 x     8 x    26               151424     100.0%      0.0%      0.0%
+ flops    26 x     8 x    13               151424     100.0%      0.0%      0.0%
+ flops     8 x     1 x   381               158496     100.0%      0.0%      0.0%
+ flops   381 x     1 x     8               158496     100.0%      0.0%      0.0%
+ flops     8 x     1 x   384               159744     100.0%      0.0%      0.0%
+ flops   384 x     1 x     8               159744     100.0%      0.0%      0.0%
+ flops     8 x     8 x    26               189696     100.0%      0.0%      0.0%
+ flops     8 x     8 x     8               218112     100.0%      0.0%      0.0%
+ flops    26 x     8 x     8               219648     100.0%      0.0%      0.0%
+ flops    77 x     1 x    64               275968     100.0%      0.0%      0.0%
+ flops    64 x     1 x    77               275968     100.0%      0.0%      0.0%
+ flops    26 x     8 x    26               302848     100.0%      0.0%      0.0%
+ flops    77 x     1 x    77               332024     100.0%      0.0%      0.0%
+ flops    85 x     1 x   381               388620     100.0%      0.0%      0.0%
+ flops   381 x     1 x    85               388620     100.0%      0.0%      0.0%
+ flops    85 x     1 x   384               391680     100.0%      0.0%      0.0%
+ flops   384 x     1 x    85               391680     100.0%      0.0%      0.0%
+ flops    25 x     5 x     8               468000     100.0%      0.0%      0.0%
+ flops     5 x    25 x     8               468000     100.0%      0.0%      0.0%
+ flops    13 x    21 x    21               515970     100.0%      0.0%      0.0%
+ flops     5 x     8 x     5               849600     100.0%      0.0%      0.0%
+ flops     5 x    32 x    32               983040     100.0%      0.0%      0.0%
+ flops     1 x     1 x   363              1026564     100.0%      0.0%      0.0%
+ flops    77 x     1 x   381              1056132     100.0%      0.0%      0.0%
+ flops   381 x     1 x    77              1056132     100.0%      0.0%      0.0%
+ flops    77 x     1 x   384              1064448     100.0%      0.0%      0.0%
+ flops   384 x     1 x    77              1064448     100.0%      0.0%      0.0%
+ flops    77 x     1 x   363              1118040     100.0%      0.0%      0.0%
+ flops   363 x     1 x    77              1118040     100.0%      0.0%      0.0%
+ flops    86 x     1 x    64              1221888     100.0%      0.0%      0.0%
+ flops    64 x     1 x    86              1221888     100.0%      0.0%      0.0%
+ flops     9 x     9 x   381              1604772     100.0%      0.0%      0.0%
+ flops     9 x     9 x   384              1617408     100.0%      0.0%      0.0%
+ flops    86 x     1 x    86              1641912     100.0%      0.0%      0.0%
+ flops     5 x    13 x     8              1825200     100.0%      0.0%      0.0%
+ flops    13 x     5 x     8              1825200     100.0%      0.0%      0.0%
+ flops     5 x     5 x    85              2677500     100.0%      0.0%      0.0%
+ flops    25 x    25 x     8              2730000     100.0%      0.0%      0.0%
+ flops     5 x    21 x     5              2759400     100.0%      0.0%      0.0%
+ flops     1 x     1 x   381              2911602     100.0%      0.0%      0.0%
+ flops     1 x     1 x   384              2934528     100.0%      0.0%      0.0%
+ flops   381 x     8 x     8              2974848     100.0%      0.0%      0.0%
+ flops   384 x     8 x     8              2998272     100.0%      0.0%      0.0%
+ flops     9 x     1 x   381              3545586     100.0%      0.0%      0.0%
+ flops   381 x     1 x     9              3545586     100.0%      0.0%      0.0%
+ flops     9 x     1 x   384              3573504     100.0%      0.0%      0.0%
+ flops   384 x     1 x     9              3573504     100.0%      0.0%      0.0%
+ flops     8 x     8 x   381              3657600     100.0%      0.0%      0.0%
+ flops     8 x     8 x   384              3686400     100.0%      0.0%      0.0%
+ flops    25 x     8 x     5              4248000     100.0%      0.0%      0.0%
+ flops     5 x     8 x    25              4248000     100.0%      0.0%      0.0%
+ flops    25 x    32 x    32              4915200     100.0%      0.0%      0.0%
+ flops    78 x     1 x    64              5341440     100.0%      0.0%      0.0%
+ flops    64 x     1 x    78              5341440     100.0%      0.0%      0.0%
+ flops    64 x     1 x    64              5570560     100.0%      0.0%      0.0%
+ flops    78 x     1 x    78              6509880     100.0%      0.0%      0.0%
+ flops     5 x    13 x     5              6739200     100.0%      0.0%      0.0%
+ flops    86 x     1 x   381              7274052     100.0%      0.0%      0.0%
+ flops   381 x     1 x    86              7274052     100.0%      0.0%      0.0%
+ flops    86 x     1 x   384              7331328     100.0%      0.0%      0.0%
+ flops   384 x     1 x    86              7331328     100.0%      0.0%      0.0%
+ flops     5 x     1 x     5              8474400     100.0%      0.0%      0.0%
+ flops    25 x    13 x     8              9126000     100.0%      0.0%      0.0%
+ flops    13 x    25 x     8              9126000     100.0%      0.0%      0.0%
+ flops     5 x     5 x    77              9702000     100.0%      0.0%      0.0%
+ flops     5 x     5 x    64             10080000     100.0%      0.0%      0.0%
+ flops    25 x     5 x    85             11475000     100.0%      0.0%      0.0%
+ flops     5 x    25 x    85             11475000     100.0%      0.0%      0.0%
+ flops    25 x    21 x     5             13797000     100.0%      0.0%      0.0%
+ flops     5 x    21 x    25             13797000     100.0%      0.0%      0.0%
+ flops     5 x     8 x    13             16567200     100.0%      0.0%      0.0%
+ flops    13 x     8 x     5             16567200     100.0%      0.0%      0.0%
+ flops   363 x     1 x    64             17842176     100.0%      0.0%      0.0%
+ flops    64 x     1 x   363             17842176     100.0%      0.0%      0.0%
+ flops    13 x    32 x    32             18849792     100.0%      0.0%      0.0%
+ flops    78 x     1 x   363             20612592     100.0%      0.0%      0.0%
+ flops   363 x     1 x    78             20612592     100.0%      0.0%      0.0%
+ flops    78 x     1 x   381             20980908     100.0%      0.0%      0.0%
+ flops   381 x     1 x    78             20980908     100.0%      0.0%      0.0%
+ flops    78 x     1 x   384             21146112     100.0%      0.0%      0.0%
+ flops   384 x     1 x    78             21146112     100.0%      0.0%      0.0%
+ flops    25 x     8 x    25             21240000     100.0%      0.0%      0.0%
+ flops   381 x     1 x    64             23798784     100.0%      0.0%      0.0%
+ flops    64 x     1 x   381             23798784     100.0%      0.0%      0.0%
+ flops    64 x     1 x   384             23986176     100.0%      0.0%      0.0%
+ flops   384 x     1 x    64             23986176     100.0%      0.0%      0.0%
+ flops    64 x    86 x   381             25164288     100.0%      0.0%      0.0%
+ flops    86 x    64 x   381             25164288     100.0%      0.0%      0.0%
+ flops    64 x    86 x   384             25362432     100.0%      0.0%      0.0%
+ flops    86 x    64 x   384             25362432     100.0%      0.0%      0.0%
+ flops    25 x    13 x     5             33696000     100.0%      0.0%      0.0%
+ flops     5 x    13 x    25             33696000     100.0%      0.0%      0.0%
+ flops    86 x    86 x   381             33814512     100.0%      0.0%      0.0%
+ flops    86 x    86 x   384             34080768     100.0%      0.0%      0.0%
+ flops    13 x    13 x     8             36609456     100.0%      0.0%      0.0%
+ flops    25 x     5 x    77             41580000     100.0%      0.0%      0.0%
+ flops     5 x    25 x    77             41580000     100.0%      0.0%      0.0%
+ flops    25 x     1 x     5             42372000     100.0%      0.0%      0.0%
+ flops     5 x     1 x    25             42372000     100.0%      0.0%      0.0%
+ flops    25 x     5 x    64             43200000     100.0%      0.0%      0.0%
+ flops     5 x    25 x    64             43200000     100.0%      0.0%      0.0%
+ flops     5 x    13 x    85             44752500     100.0%      0.0%      0.0%
+ flops    13 x     5 x    85             44752500     100.0%      0.0%      0.0%
+ flops     5 x    21 x    13             53808300     100.0%      0.0%      0.0%
+ flops    13 x    21 x     5             53808300     100.0%      0.0%      0.0%
+ flops   381 x     8 x   381             60386976     100.0%      0.0%      0.0%
+ flops   381 x     8 x   384             60862464     100.0%      0.0%      0.0%
+ flops   384 x     8 x   381             60862464     100.0%      0.0%      0.0%
+ flops   384 x     8 x   384             61341696     100.0%      0.0%      0.0%
+ flops    25 x    25 x    85             66937500     100.0%      0.0%      0.0%
+ flops    64 x    78 x   381             68470272     100.0%      0.0%      0.0%
+ flops    78 x    64 x   381             68470272     100.0%      0.0%      0.0%
+ flops    25 x    21 x    25             68985000     100.0%      0.0%      0.0%
+ flops    64 x    78 x   384             69009408     100.0%      0.0%      0.0%
+ flops    78 x    64 x   384             69009408     100.0%      0.0%      0.0%
+ flops    64 x    78 x   363             72483840     100.0%      0.0%      0.0%
+ flops    78 x    64 x   363             72483840     100.0%      0.0%      0.0%
+ flops    25 x     8 x    13             82836000     100.0%      0.0%      0.0%
+ flops    13 x     8 x    25             82836000     100.0%      0.0%      0.0%
+ flops     5 x    32 x     5             83174400     100.0%      0.0%      0.0%
+ flops    78 x    78 x   381             83448144     100.0%      0.0%      0.0%
+ flops    78 x    78 x   384             84105216     100.0%      0.0%      0.0%
+ flops    78 x    78 x   363             88339680     100.0%      0.0%      0.0%
+ flops    13 x    13 x     5            128402820     100.0%      0.0%      0.0%
+ flops     5 x    13 x    13            128433240     100.0%      0.0%      0.0%
+ flops     5 x    13 x    77            158468310     100.0%      0.0%      0.0%
+ flops    13 x     5 x    77            158468310     100.0%      0.0%      0.0%
+ flops     5 x     1 x    13            163526220     100.0%      0.0%      0.0%
+ flops    13 x     1 x     5            163526220     100.0%      0.0%      0.0%
+ flops     5 x    13 x    64            165409920     100.0%      0.0%      0.0%
+ flops    13 x     5 x    64            165409920     100.0%      0.0%      0.0%
+ flops    25 x    13 x    25            168480000     100.0%      0.0%      0.0%
+ flops    64 x    64 x    85            177561600     100.0%      0.0%      0.0%
+ flops    64 x    85 x    64            177561600     100.0%      0.0%      0.0%
+ flops    85 x    64 x    64            177561600     100.0%      0.0%      0.0%
+ flops    25 x     1 x    25            211860000     100.0%      0.0%      0.0%
+ flops    25 x    13 x    85            223762500     100.0%      0.0%      0.0%
+ flops    13 x    25 x    85            223762500     100.0%      0.0%      0.0%
+ flops    85 x    85 x    64            235824000     100.0%      0.0%      0.0%
+ flops    64 x    85 x    85            235824000     100.0%      0.0%      0.0%
+ flops    85 x    64 x    85            235824000     100.0%      0.0%      0.0%
+ flops    25 x    25 x    77            242550000     100.0%      0.0%      0.0%
+ flops    25 x    25 x    64            252000000     100.0%      0.0%      0.0%
+ flops    25 x    21 x    13            269041500     100.0%      0.0%      0.0%
+ flops    13 x    21 x    25            269041500     100.0%      0.0%      0.0%
+ flops    85 x    85 x    85            313203750     100.0%      0.0%      0.0%
+ flops    13 x     8 x    13            324085216     100.0%      0.0%      0.0%
+ flops    25 x    32 x     5            415872000     100.0%      0.0%      0.0%
+ flops     5 x    32 x    25            415872000     100.0%      0.0%      0.0%
+ flops    64 x    85 x   381            509869440     100.0%      0.0%      0.0%
+ flops    85 x    64 x   381            509869440     100.0%      0.0%      0.0%
+ flops    64 x    85 x   384            513884160     100.0%      0.0%      0.0%
+ flops    85 x    64 x   384            513884160     100.0%      0.0%      0.0%
+ flops   381 x    85 x    64            601065600     100.0%      0.0%      0.0%
+ flops   381 x    64 x    85            601065600     100.0%      0.0%      0.0%
+ flops   384 x    64 x    85            605798400     100.0%      0.0%      0.0%
+ flops   384 x    85 x    64            605798400     100.0%      0.0%      0.0%
+ flops    13 x    13 x    25            642014100     100.0%      0.0%      0.0%
+ flops    25 x    13 x    13            642166200     100.0%      0.0%      0.0%
+ flops    64 x    64 x    77            659800064     100.0%      0.0%      0.0%
+ flops    64 x    77 x    64            659800064     100.0%      0.0%      0.0%
+ flops    77 x    64 x    64            659800064     100.0%      0.0%      0.0%
+ flops    85 x    85 x   381            677170350     100.0%      0.0%      0.0%
+ flops    64 x    64 x    64            682098688     100.0%      0.0%      0.0%
+ flops    85 x    85 x   384            682502400     100.0%      0.0%      0.0%
+ flops    25 x    13 x    77            792341550     100.0%      0.0%      0.0%
+ flops    13 x    25 x    77            792341550     100.0%      0.0%      0.0%
+ flops    77 x    77 x    64            793821952     100.0%      0.0%      0.0%
+ flops    64 x    77 x    77            793821952     100.0%      0.0%      0.0%
+ flops    77 x    64 x    77            793821952     100.0%      0.0%      0.0%
+ flops   381 x    85 x    85            798290250     100.0%      0.0%      0.0%
+ flops   384 x    85 x    85            804576000     100.0%      0.0%      0.0%
+ flops    25 x     1 x    13            817631100     100.0%      0.0%      0.0%
+ flops    13 x     1 x    25            817631100     100.0%      0.0%      0.0%
+ flops    25 x    13 x    64            827049600     100.0%      0.0%      0.0%
+ flops    13 x    25 x    64            827049600     100.0%      0.0%      0.0%
+ flops    13 x    13 x    85            892066500     100.0%      0.0%      0.0%
+ flops    77 x    77 x    77            955067036     100.0%      0.0%      0.0%
+ flops    13 x    21 x    13           1049261850     100.0%      0.0%      0.0%
+ flops    64 x    64 x   363           1076477952     100.0%      0.0%      0.0%
+ flops   363 x    64 x    64           1189478400     100.0%      0.0%      0.0%
+ flops    64 x    77 x   363           1223582976     100.0%      0.0%      0.0%
+ flops    77 x    64 x   363           1223582976     100.0%      0.0%      0.0%
+ flops    64 x    77 x   381           1246705152     100.0%      0.0%      0.0%
+ flops    77 x    64 x   381           1246705152     100.0%      0.0%      0.0%
+ flops    64 x    77 x   384           1256521728     100.0%      0.0%      0.0%
+ flops    77 x    64 x   384           1256521728     100.0%      0.0%      0.0%
+ flops   363 x    77 x    64           1431091200     100.0%      0.0%      0.0%
+ flops   363 x    64 x    77           1431091200     100.0%      0.0%      0.0%
+ flops   381 x    77 x    64           1464503040     100.0%      0.0%      0.0%
+ flops   381 x    64 x    77           1464503040     100.0%      0.0%      0.0%
+ flops    77 x    77 x   363           1472123268     100.0%      0.0%      0.0%
+ flops   384 x    64 x    77           1476034560     100.0%      0.0%      0.0%
+ flops   384 x    77 x    64           1476034560     100.0%      0.0%      0.0%
+ flops   381 x    85 x   381           1480642200     100.0%      0.0%      0.0%
+ flops   381 x    85 x   384           1492300800     100.0%      0.0%      0.0%
+ flops   384 x    85 x   381           1492300800     100.0%      0.0%      0.0%
+ flops    64 x    64 x   381           1495031808     100.0%      0.0%      0.0%
+ flops    77 x    77 x   381           1499942136     100.0%      0.0%      0.0%
+ flops   384 x    85 x   384           1504051200     100.0%      0.0%      0.0%
+ flops    64 x    64 x   384           1506803712     100.0%      0.0%      0.0%
+ flops    77 x    77 x   384           1511752704     100.0%      0.0%      0.0%
+ flops     5 x    32 x    13           1592248320     100.0%      0.0%      0.0%
+ flops    13 x    32 x     5           1592248320     100.0%      0.0%      0.0%
+ flops   381 x    64 x    64           1669816320     100.0%      0.0%      0.0%
+ flops   384 x    64 x    64           1682964480     100.0%      0.0%      0.0%
+ flops   363 x    77 x    77           1721781600     100.0%      0.0%      0.0%
+ flops   381 x    77 x    77           1761980220     100.0%      0.0%      0.0%
+ flops   384 x    77 x    77           1775854080     100.0%      0.0%      0.0%
+ flops    25 x    32 x    25           2079360000     100.0%      0.0%      0.0%
+ flops    13 x    13 x    13           2449624242     100.0%      0.0%      0.0%
+ flops    13 x    13 x    77           3091576488     100.0%      0.0%      0.0%
+ flops    13 x     1 x    13           3158125308     100.0%      0.0%      0.0%
+ flops    13 x    13 x    64           3241295616     100.0%      0.0%      0.0%
+ flops   381 x    77 x   381           3576767040     100.0%      0.0%      0.0%
+ flops   381 x    77 x   384           3604930560     100.0%      0.0%      0.0%
+ flops   384 x    77 x   381           3604930560     100.0%      0.0%      0.0%
+ flops   384 x    77 x   384           3633315840     100.0%      0.0%      0.0%
+ flops   381 x    64 x   381           4087733760     100.0%      0.0%      0.0%
+ flops   384 x    64 x   381           4119920640     100.0%      0.0%      0.0%
+ flops   381 x    64 x   384           4119920640     100.0%      0.0%      0.0%
+ flops   384 x    64 x   384           4152360960     100.0%      0.0%      0.0%
+ flops   363 x    64 x   363           5532189696     100.0%      0.0%      0.0%
+ flops   363 x    77 x   363           6655915728     100.0%      0.0%      0.0%
+ flops    25 x    32 x    13           7961241600     100.0%      0.0%      0.0%
+ flops    13 x    32 x    25           7961241600     100.0%      0.0%      0.0%
+ flops    13 x    32 x    13          30509167104     100.0%      0.0%      0.0%
+ flops inhomo. stacks                    10629464     100.0%      0.0%      0.0%
+ flops total                       177.183718E+09     100.0%      0.0%      0.0%
+ flops max/rank                     50.747522E+09     100.0%      0.0%      0.0%
+ matmuls inhomo. stacks                     25664     100.0%      0.0%      0.0%
+ matmuls total                           21520949     100.0%      0.0%      0.0%
+ number of processed stacks                296093     100.0%      0.0%      0.0%
+ average stack size                                    72.7       0.0       0.0
+ marketing flops                   189.352133E+09
+ -------------------------------------------------------------------------------
+ # multiplications                          36240
+ max memory usage/rank             316.108800E+06
+ # max total images/rank                        1
+ # max 3D layers                                1
+ # MPI messages exchanged                  289920
+ MPI messages size (bytes):
+  total size                        29.767862E+09
+  min size                           0.000000E+00
+  max size                           1.179648E+06
+  average size                     102.676125E+03
+ MPI breakdown and total messages size (bytes):
+             size <=      128              180549                   441376
+       128 < size <=     8192               51023                140668704
+      8192 < size <=    32768                6945                209895632
+     32768 < size <=   131072               12051                523071832
+    131072 < size <=  4194304               39352              28893828816
+   4194304 < size <= 16777216                   0                        0
+  16777216 < size                               0                        0
+ -------------------------------------------------------------------------------
+
+ MEMORY| Estimated peak process memory [MiB]                                 302
+
+ -------------------------------------------------------------------------------
+ ----                             MULTIGRID INFO                            ----
+ -------------------------------------------------------------------------------
+ count for grid        1:          93968          cutoff [a.u.]          150.00
+ count for grid        2:          47024          cutoff [a.u.]           50.00
+ count for grid        3:          32144          cutoff [a.u.]           16.67
+ count for grid        4:          11760          cutoff [a.u.]            5.56
+ total gridlevel count  :         184896
+
+ -------------------------------------------------------------------------------
+ -                                                                             -
+ -                         MESSAGE PASSING PERFORMANCE                         -
+ -                                                                             -
+ -------------------------------------------------------------------------------
+
+ ROUTINE             CALLS      AVE VOLUME [Bytes]
+ MP_Group             1347
+ MP_Bcast            16503                 143496.
+ MP_Allreduce       110774                     88.
+ MP_Sync                24
+ MP_Alltoall        116072                 537303.
+ MP_ISendRecv         4203                1252451.
+ MP_Wait           1163883
+ MP_ISend           289512                  27187.
+ MP_IRecv           289512                  26808.
+ MP_Recv                26                 179461.
+ MP_Memory         1466638
+ -------------------------------------------------------------------------------
+
+
+ -------------------------------------------------------------------------------
+ -                                                                             -
+ -                           R E F E R E N C E S                               -
+ -                                                                             -
+ -------------------------------------------------------------------------------
+ 
+ CP2K version 5.1, the CP2K developers group (2017).
+ CP2K is freely available from https://www.cp2k.org/ .
+
+ Schuett, Ole; Messmer, Peter; Hutter, Juerg; VandeVondele, Joost. 
+ Electronic Structure Calculations on Graphics Processing Units, John Wiley & Sons, Ltd, 173-190 (2016). 
+ GPU-Accelerated Sparse Matrix-Matrix Multiplication for Linear Scaling Density Functional Theory.
+ http://dx.doi.org/10.1002/9781118670712.ch8
+
+
+ Borstnik, U; VandeVondele, J; Weber, V; Hutter, J. 
+ PARALLEL COMPUTING, 40 (5-6), 47-58 (2014). 
+ Sparse matrix multiplication: The distributed block-compressed sparse
+ row library.
+ http://dx.doi.org/10.1016/j.parco.2014.03.012
+
+
+ Hutter, J; Iannuzzi, M; Schiffmann, F; VandeVondele, J. 
+ WILEY INTERDISCIPLINARY REVIEWS-COMPUTATIONAL MOLECULAR SCIENCE, 4 (1), 15-25 (2014). 
+ CP2K: atomistic simulations of condensed matter systems.
+ http://dx.doi.org/10.1002/wcms.1159
+
+
+ Grimme, S; Ehrlich, S; Goerigk, L. 
+ JOURNAL OF COMPUTATIONAL CHEMISTRY, 32, 1456 (2011). 
+ Effect of the damping function in dispersion corrected density functional theory.
+ http://dx.doi.org/10.1002/jcc.21759
+
+
+ Grimme, S; Antony, J; Ehrlich, S; Krieg, H. 
+ JOURNAL OF CHEMICAL PHYSICS, 132 (15), 154104 (2010). 
+ A consistent and accurate ab initio parametrization of density
+ functional dispersion correction (DFT-D) for the 94 elements H-Pu.
+ http://dx.doi.org/10.1063/1.3382344
+
+
+ VandeVondele, J; Hutter, J. 
+ JOURNAL OF CHEMICAL PHYSICS, 127 (11), 114105 (2007). 
+ Gaussian basis sets for accurate calculations on molecular systems in
+ gas and condensed phases.
+ http://dx.doi.org/10.1063/1.2770708
+
+
+ Krack, M. 
+ THEORETICAL CHEMISTRY ACCOUNTS, 114 (1-3), 145-152 (2005). 
+ Pseudopotentials for H to Kr optimized for gradient-corrected
+ exchange-correlation functionals.
+ http://dx.doi.org/10.1007/s00214-005-0655-y
+
+
+ VandeVondele, J; Krack, M; Mohamed, F; Parrinello, M; Chassaing, T;
+ Hutter, J. COMPUTER PHYSICS COMMUNICATIONS, 167 (2), 103-128 (2005). 
+ QUICKSTEP: Fast and accurate density functional calculations using a
+ mixed Gaussian and plane waves approach.
+ http://dx.doi.org/10.1016/j.cpc.2004.12.014
+
+
+ Frigo, M; Johnson, SG. 
+ PROCEEDINGS OF THE IEEE, 93 (2), 216-231 (2005). 
+ The design and implementation of FFTW3.
+ http://dx.doi.org/10.1109/JPROC.2004.840301
+
+
+ VandeVondele, J; Hutter, J. 
+ JOURNAL OF CHEMICAL PHYSICS, 118 (10), 4365-4369 (2003). 
+ An efficient orbital transformation method for electronic structure
+ calculations.
+ http://dx.doi.org/10.1063/1.1543154
+
+
+ Hartwigsen, C; Goedecker, S; Hutter, J. 
+ PHYSICAL REVIEW B, 58 (7), 3641-3662 (1998). 
+ Relativistic separable dual-space Gaussian pseudopotentials from H to Rn.
+ http://dx.doi.org/10.1103/PhysRevB.58.3641
+
+
+ Lippert, G; Hutter, J; Parrinello, M. 
+ MOLECULAR PHYSICS, 92 (3), 477-487 (1997). 
+ A hybrid Gaussian and plane wave density functional scheme.
+ http://dx.doi.org/10.1080/002689797170220
+
+
+ Perdew, JP; Burke, K; Ernzerhof, M. 
+ PHYSICAL REVIEW LETTERS, 77 (18), 3865-3868 (1996). 
+ Generalized gradient approximation made simple.
+ http://dx.doi.org/10.1103/PhysRevLett.77.3865
+
+
+ Goedecker, S; Teter, M; Hutter, J. 
+ PHYSICAL REVIEW B, 54 (3), 1703-1710 (1996). 
+ Separable dual-space Gaussian pseudopotentials.
+ http://dx.doi.org/10.1103/PhysRevB.54.1703
+
+
+ -------------------------------------------------------------------------------
+ -                                                                             -
+ -                                T I M I N G                                  -
+ -                                                                             -
+ -------------------------------------------------------------------------------
+ SUBROUTINE                       CALLS  ASD         SELF TIME        TOTAL TIME
+                                MAXIMUM       AVERAGE  MAXIMUM  AVERAGE  MAXIMUM
+ CP2K                                 1  1.0    0.015    0.024  450.206  450.207
+ qs_energies                          5  2.0    0.000    0.000  448.421  448.421
+ scf_env_do_scf                       5  3.0    0.000    0.001  417.768  417.768
+ scf_env_do_scf_inner_loop          172  4.0    0.008    0.012  407.619  407.619
+ qs_ks_update_qs_env                178  5.0    0.001    0.001  261.804  261.884
+ rebuild_ks_matrix                  172  6.0    0.000    0.000  261.731  261.810
+ qs_ks_build_kohn_sham_matrix       172  7.0    0.021    0.022  261.731  261.810
+ qs_rho_update_rho                  177  5.0    0.001    0.001  145.677  145.737
+ calculate_rho_elec                 177  6.0  103.013  110.370  145.676  145.736
+ pw_transfer                       3298  9.6    0.261    0.264  129.457  131.163
+ fft_wrap_pw1pw2                   2954 10.7    0.037    0.038  127.466  129.169
+ fft_wrap_pw1pw2_150               1907 11.8   12.083   12.438  122.593  124.255
+ sum_up_and_integrate               172  8.0    0.433    0.442  114.868  122.193
+ integrate_v_rspace                 172  9.0   95.228  102.557  114.435  121.758
+ qs_vxc_create                      172  8.0    0.003    0.003  117.912  118.035
+ xc_vxc_pw_create                   172  9.0    1.498    1.723  117.909  118.032
+ fft3d_ps                          2954 12.7   53.960   54.505   88.331   91.090
+ xc_rho_set_and_dset_create         172 10.0    0.768    0.805   65.544   66.339
+ dbcsr_multiply_generic           36240  8.1    0.753    0.772   44.912   52.245
+ density_rs2pw                      177  7.0    0.011    0.011   41.051   46.885
+ make_m2s                         72480  9.1    0.428    0.435   22.213   28.819
+ make_images                      72480 10.1    0.845    0.868   20.262   26.896
+ scf_post_calculation_gpw             5  3.0    0.000    0.000   25.955   25.955
+ rs_pw_transfer                    1401  9.5    0.023    0.024   20.052   25.954
+ make_lumo                            5  4.0    0.000    0.000   25.869   25.869
+ ot_eigensolver                       5  5.0    0.028    0.031   25.855   25.855
+ mp_waitall_1                   1163883 12.2   17.569   24.217   17.569   24.217
+ xc_functional_eval                 172 11.0    0.002    0.002   23.327   24.076
+ pbe_lda_eval                       172 12.0   23.325   24.074   23.325   24.074
+ x_to_yz                           1553 14.2   13.304   13.535   19.958   20.122
+ multiply_cannon                  36240  9.1    1.618    1.731   18.031   19.534
+ rs_pw_transfer_RS2PW_150           182  8.9    2.919    3.003   13.624   19.482
+ potential_pw2rs                    172 10.0    0.033    0.036   19.185   19.192
+ mp_alltoall_z22v                  2954 14.7   14.237   17.639   14.237   17.639
+ yz_to_x                           1401 13.1    6.768    7.023   14.351   17.465
+ make_images_sizes                72480 11.1    0.043    0.045    9.563   16.115
+ mp_alltoall_i44                  72480 12.1    9.520   16.070    9.520   16.070
+ pw_scatter_p                      1553 13.2   14.274   14.433   14.274   14.433
+ pw_gather_p                       1401 12.1   12.364   13.032   12.364   13.032
+ ot_mini                           2615  6.1    0.009    0.010   12.756   12.833
+ qs_scf_new_mos                     172  5.0    0.001    0.001   11.670   11.783
+ qs_scf_loop_do_ot                  172  6.0    0.001    0.001   11.668   11.782
+ multiply_cannon_multrec          72480 10.1    8.319   10.944    9.123   11.196
+ ot_scf_mini                        172  7.0    0.006    0.007   10.720   10.807
+ init_scf_loop                        6  4.0    0.000    0.000   10.145   10.145
+ qs_ot_get_derivative              1396  7.2    0.007    0.008    9.409    9.482
+ pw_derive                         1032 10.5    9.216    9.381    9.216    9.381
+ -------------------------------------------------------------------------------
+
+ The number of warnings for this run is : 0
+ 
+ -------------------------------------------------------------------------------
+  **** **** ******  **  PROGRAM ENDED AT                 2020-01-15 16:17:25.880
+ ***** ** ***  *** **   PROGRAM RAN ON                             daniele-Ubu18
+ **    ****   ******    PROGRAM RAN BY                                   daniele
+ ***** **    ** ** **   PROGRAM PROCESS ID                                 25190
+  **** **  *******  **  PROGRAM STOPPED IN /home/daniele/dev_aiida/aiida_run/42/
+                                           44/db1b-725a-45fb-864b-3c8fb1336084
+

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+# Copyright (c), The AiiDA-CP2K authors.                                      #
+# SPDX-License-Identifier: MIT                                                #
+# AiiDA-CP2K is hosted on GitHub at https://github.com/cp2k/aiida-cp2k        #
+# For further information on the license, see the LICENSE.txt file.           #
+###############################################################################
+"""Test Cp2k output parsers."""
+from __future__ import absolute_import
+import os
+
+from aiida_lsmo.parsers.parser_functions import parse_cp2k_output_bsse
+
+CWD = os.path.dirname(os.path.realpath(__file__))
+
+
+def test_bsse_parser():
+    """Testing BSSE parser."""
+    with open(os.path.join(CWD, 'outputs', 'BSSE_output_v5.1_.out')) as fobj:
+        res = parse_cp2k_output_bsse(fobj)
+        assert res["exceeded_walltime"] is False
+        assert res["energy_description_list"] == [
+            "Energy of A with basis set A", "Energy of B with basis set B", "Energy of A with basis set of A+B",
+            "Energy of B with basis set of A+B", "Energy of A+B with basis set of A+B"
+        ]
+        assert res["energy_list"] == [
+            -792.146217025347, -37.76185844385889, -792.1474366957273, -37.76259020339316, -829.920698393915
+        ]
+        assert res["energy_dispersion_list"] == [
+            -0.15310795077994, -0.0009680299214, -0.15310795077994, -0.0009680299214, -0.16221221242898
+        ]
+        assert res["energy"] == -829.920698393915
+        assert res["energy_units"] == "a.u."
+        assert res["binding_energy_raw"] == -33.14148882373938
+        assert res["binding_energy_corr"] == -28.018009583204375
+        assert res["binding_energy_bsse"] == -5.123479240535005
+        assert res["binding_energy_unit"] == "kJ/mol"
+        assert res["binding_energy_dispersion"] == -21.361676400918867


### PR DESCRIPTION
Moved Multistage work chain from aiida-cp2k to aiida-lsmo. 
For the moment I don't do the same for Cp2kDdec which stays in aiida-ddec.

TODO:
- approve this PR
- make a PR for aiida-cp2k, and a new release
- update the requirements to the new aiida-cp2k release (or there will be double entry points!)
- release a new aiida-lsmo that I would call `1.0.0`