### PR TITLE
Adapt the cp2k parsers to the new aiida-cp2k package.

### DIFF
--- a/aiida_lsmo/parsers/__init__.py
+++ b/aiida_lsmo/parsers/__init__.py
@@ -7,9 +7,8 @@ from aiida.common import OutputParsingError, NotExistent
 from aiida.engine import ExitCode
 from aiida.orm import Dict, BandsData
 from aiida.plugins import ParserFactory
+from aiida_cp2k.parsers import Cp2kBaseParser
 from .parser_functions import parse_cp2k_output_bsse, parse_cp2k_output_advanced
-
-Cp2kBaseParser = ParserFactory('cp2k_base_parser')  # pylint: disable=invalid-name
 
 
 class Cp2kBsseParser(Cp2kBaseParser):  # pylint: disable=too-few-public-methods

--- a/aiida_lsmo/parsers/__init__.py
+++ b/aiida_lsmo/parsers/__init__.py
@@ -3,96 +3,32 @@
 import io
 import os
 
-from aiida.parsers import Parser
 from aiida.common import OutputParsingError, NotExistent
 from aiida.engine import ExitCode
-from aiida.orm import Dict
+from aiida.orm import Dict, BandsData
+from aiida.plugins import ParserFactory
+from .parser_functions import parse_cp2k_output_bsse, parse_cp2k_output_advanced
+
+Cp2kBaseParser = ParserFactory('cp2k_base_parser')  # pylint: disable=invalid-name
 
 
-class Cp2kBaseParser(Parser):
-    """Basic AiiDA parser for the output of CP2K.
-    NOTE: copy of the parser in aiida_cp2k.parser, because the docs were failing when importing it from aiida_cp2k:
-    docstring of aiida_lsmo.parsers.Cp2kAdvancedParser:1:py:class
-    reference target not found: aiida_cp2k.parsers.Cp2kBaseParser
-    """
-
-    def parse(self, **kwargs):
-        """Receives in input a dictionary of retrieved nodes. Does all the logic here."""
-
-        try:
-            out_folder = self.retrieved
-        except NotExistent:
-            return self.exit_codes.ERROR_NO_RETRIEVED_FOLDER
-
-        self._parse_stdout(out_folder)
-
-        try:
-            structure = self._parse_trajectory(out_folder)
-            self.out('output_structure', structure)
-        except Exception:  # pylint: disable=broad-except
-            pass
-
-        return ExitCode(0)
-
-    def _parse_stdout(self, out_folder):
-        """Basic CP2K output file parser"""
-
-        from aiida_cp2k.utils import parse_cp2k_output
-
-        # pylint: disable=protected-access
-
-        fname = self.node.process_class._DEFAULT_OUTPUT_FILE
-        if fname not in out_folder._repository.list_object_names():
-            raise OutputParsingError("Cp2k output file not retrieved")
-
-        abs_fn = os.path.join(out_folder._repository._get_base_folder().abspath, fname)
-
-        with io.open(abs_fn, mode="r", encoding="utf-8") as fobj:
-            result_dict = parse_cp2k_output(fobj)
-
-        if 'nwarnings' not in result_dict:
-            raise OutputParsingError("CP2K did not finish properly.")
-
-        self.out("output_parameters", Dict(dict=result_dict))
-
-    def _parse_trajectory(self, out_folder):
-        """CP2K trajectory parser"""
-
-        from ase import Atoms
-        from aiida.orm import StructureData
-        from aiida_cp2k.utils import parse_cp2k_trajectory
-
-        # pylint: disable=protected-access
-        fname = self.node.process_class._DEFAULT_RESTART_FILE_NAME
-
-        if fname not in out_folder._repository.list_object_names():
-            raise Exception("parsing trajectory requested, but no trajectory file available")
-
-        # read restart file
-        abs_fn = os.path.join(out_folder._repository._get_base_folder().abspath, fname)
-        with io.open(abs_fn, mode="r", encoding="utf-8") as fobj:
-            atoms = Atoms(**parse_cp2k_trajectory(fobj))
-
-        return StructureData(ase=atoms)
-
-
-class Cp2kBsseParser(Cp2kBaseParser):
+class Cp2kBsseParser(Cp2kBaseParser):  # pylint: disable=too-few-public-methods
     """Advanced AiiDA parser class for a BSSE calculation in CP2K."""
 
-    def _parse_stdout(self, out_folder):
+    def _parse_stdout(self):
         """BSSE CP2K output file parser"""
 
-        from .parser_functions import parse_cp2k_output_bsse
+        fname = self.node.get_attribute('output_filename')
 
-        # pylint: disable=protected-access
+        if fname not in self.retrieved.list_object_names():
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_MISSING
 
-        fname = self.node.process_class._DEFAULT_OUTPUT_FILE
-        if fname not in out_folder._repository.list_object_names():
-            raise OutputParsingError("Cp2k output file not retrieved")
+        try:
+            output_string = self.retrieved.get_object_content(fname)
+        except IOError:
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
 
-        abs_fn = os.path.join(out_folder._repository._get_base_folder().abspath, fname)
-        with io.open(abs_fn, mode="r", encoding="utf-8") as fobj:
-            result_dict = parse_cp2k_output_bsse(fobj)
+        result_dict = parse_cp2k_output_bsse(output_string)
 
         # nwarnings is the last thing to be printed in the CP2K output file:
         # if it is not there, CP2K didn't finish properly
@@ -100,26 +36,26 @@ class Cp2kBsseParser(Cp2kBaseParser):
             raise OutputParsingError("CP2K did not finish properly.")
 
         self.out("output_parameters", Dict(dict=result_dict))
+        return None
 
 
-class Cp2kAdvancedParser(Cp2kBaseParser):
+class Cp2kAdvancedParser(Cp2kBaseParser):  # pylint: disable=too-few-public-methods
     """Advanced AiiDA parser class for the output of CP2K."""
 
-    def _parse_stdout(self, out_folder):
+    def _parse_stdout(self):
         """Advanced CP2K output file parser"""
 
-        from aiida.orm import BandsData
-        from .parser_functions import parse_cp2k_output_advanced
+        fname = self.node.get_attribute('output_filename')
 
-        # pylint: disable=protected-access
+        if fname not in self.retrieved.list_object_names():
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_MISSING
 
-        fname = self.node.process_class._DEFAULT_OUTPUT_FILE
-        if fname not in out_folder._repository.list_object_names():
-            raise OutputParsingError("Cp2k output file not retrieved")
+        try:
+            output_string = self.retrieved.get_object_content(fname)
+        except IOError:
+            return self.exit_codes.ERROR_OUTPUT_STDOUT_READ
 
-        abs_fn = os.path.join(out_folder._repository._get_base_folder().abspath, fname)
-        with io.open(abs_fn, mode="r", encoding="utf-8") as fobj:
-            result_dict = parse_cp2k_output_advanced(fobj)
+        result_dict = parse_cp2k_output_advanced(output_string)
 
         # nwarnings is the last thing to be printed in th eCP2K output file:
         # if it is not there, CP2K didn't finish properly
@@ -157,3 +93,4 @@ class Cp2kAdvancedParser(Cp2kBaseParser):
             del result_dict["kpoint_data"]
 
         self.out("output_parameters", Dict(dict=result_dict))
+        return None

--- a/aiida_lsmo/parsers/parser_functions.py
+++ b/aiida_lsmo/parsers/parser_functions.py
@@ -5,11 +5,11 @@ import re
 from aiida_cp2k.utils.parser import _parse_bands
 
 
-def parse_cp2k_output_bsse(fobj):
+def parse_cp2k_output_bsse(fstring):
     """Parse CP2K BSSE output into a dictionary (tested with PRINT_LEVEL MEDIUM)."""
     from aiida_lsmo.utils import HARTREE2KJMOL
 
-    lines = fobj.readlines()
+    lines = fstring.splitlines()
 
     result_dict = {
         "exceeded_walltime": False,
@@ -52,9 +52,9 @@ def parse_cp2k_output_bsse(fobj):
     return result_dict
 
 
-def parse_cp2k_output_advanced(fobj):  # pylint: disable=too-many-locals, too-many-statements, too-many-branches
+def parse_cp2k_output_advanced(fstring):  # pylint: disable=too-many-locals, too-many-statements, too-many-branches
     """Parse CP2K output into a dictionary (ADVANCED: more info parsed @ PRINT_LEVEL MEDIUM)"""
-    lines = fobj.readlines()
+    lines = fstring.splitlines()
 
     result_dict = {"exceeded_walltime": False}
     result_dict['warnings'] = []

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,6 +68,7 @@ extensions = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'aiida': ('http://aiida-core.readthedocs.io/en/latest/', None),
+    'aiida_cp2k': ('https://aiida-cp2k.readthedocs.io/en/latest/', None),
 }
 
 nitpick_ignore = [('py:obj', 'module')]

--- a/setup.json
+++ b/setup.json
@@ -13,7 +13,7 @@
     "include_package_data": true,
     "install_requires": [
         "aiida-core >= 1.0.0",
-        "aiida-cp2k >= 1.0.0b6",
+        "aiida-cp2k >= 1.1.0",
         "aiida-ddec >= 1.0.0a1",
         "aiida-zeopp >= 1.0.3",
         "aiida-raspa >= 1.1.0",

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -7,7 +7,7 @@ from . import DATA_DIR
 def test_bsse_parser():
     """Testing BSSE parser."""
     with open(os.path.join(DATA_DIR, 'BSSE_output_v5.1_.out')) as fobj:
-        res = parse_cp2k_output_bsse(fobj)
+        res = parse_cp2k_output_bsse(fobj.read())
         assert res["exceeded_walltime"] is False
         assert res["energy_description_list"] == [
             "Energy of A with basis set A", "Energy of B with basis set B", "Energy of A with basis set of A+B",


### PR DESCRIPTION
This PR removes the copy-pasted `BaseCp2kParser` with the parser imported
from the aiida-cp2k plugin. Due to the changes introduced recently in
https://github.com/aiidateam/aiida-cp2k/pull/84, the multistage workflow
woudn't work correctly with the latest version of the cp2k plugin.